### PR TITLE
Implement cancel_timeout and other fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       run: |
         # Install poetry and use it to install dependencies.
         python -m pip install poetry
+        if [ "${{ matrix.python-version }}" = "3.10-dev" ]; then
+            python -m poetry config experimental.new-installer false
+        fi
         python -m poetry install --no-root --no-interaction
     - name: Lint
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ 3.9 ]
+        python-version: [ 3.9, '3.10-dev' ]
 
     env:
       POETRY_RUN: "python -m poetry run"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Run Tests
       run: |
         # Run pytest.
-        $POETRY_RUN python -m pytest -vv --color=yes --log-cli-level=INFO
+        $POETRY_RUN python -m pytest -vv --timeout=10 --color=yes --log-cli-level=INFO --log-cli-format="%(created).03f %(levelname)s %(message)s"
     - name: Run Code Coverage (Linux only)
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -371,6 +371,17 @@ importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""
 pytest = "*"
 
 [[package]]
+name = "pytest-timeout"
+version = "1.4.2"
+description = "py.test plugin to abort hanging tests"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pytest = ">=3.6.0"
+
+[[package]]
 name = "python-dotenv"
 version = "0.19.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -467,7 +478,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "c50b2ab71b11cd1eca9e443ef58444ffe5c281ecf03959df0ef9b9a4af4b553b"
+content-hash = "6f890163c721e6508cbcc5ae471b656d7128a36a5a0b07a0d24a298f3ce2edb9"
 
 [metadata.files]
 appdirs = [
@@ -718,6 +729,10 @@ pytest-dotenv = [
 pytest-randomly = [
     {file = "pytest-randomly-3.10.1.tar.gz", hash = "sha256:d4ef5dbf27e542e6a4e4cec7a20ef3f1b906bce21fa340ca5657b5326ef23a64"},
     {file = "pytest_randomly-3.10.1-py3-none-any.whl", hash = "sha256:d28d490e3a743bdd64c5bc87c5fc182eac966ba6432c6bb6b224e32e76527e9e"},
+]
+pytest-timeout = [
+    {file = "pytest-timeout-1.4.2.tar.gz", hash = "sha256:20b3113cf6e4e80ce2d403b6fb56e9e1b871b510259206d40ff8d609f48bda76"},
+    {file = "pytest_timeout-1.4.2-py2.py3-none-any.whl", hash = "sha256:541d7aa19b9a6b4e475c759fd6073ef43d7cdc9a92d95644c260076eb257a063"},
 ]
 python-dotenv = [
     {file = "python-dotenv-0.19.0.tar.gz", hash = "sha256:f521bc2ac9a8e03c736f62911605c5d83970021e3fa95b37d769e2bbbe9b6172"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ codecov = "^2.1.12"
 flake8 = "^3.9.2"
 pytest-dotenv = "^0.5.2"
 pytest-randomly = "^3.10.1"
+pytest-timeout = "^1.4.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -3,6 +3,7 @@
 import asyncio
 import dataclasses
 import os
+import signal
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -35,7 +36,7 @@ class Options:  # pylint: disable=too-many-instance-attributes
     return_result: bool = False
     allowed_exit_codes: Optional[set] = None
     cancel_timeout: float = 3.0
-    cancel_signal: Optional[Any] = None
+    cancel_signal: Optional[Any] = signal.SIGTERM
 
     def merge_env(self):
         "Return our `env` merged with the global environment."

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -34,6 +34,8 @@ class Options:  # pylint: disable=too-many-instance-attributes
     encoding: Optional[str] = "utf-8"
     return_result: bool = False
     allowed_exit_codes: Optional[set] = None
+    cancel_timeout: float = 3.0
+    cancel_signal: Optional[Any] = None
 
     def merge_env(self):
         "Return our `env` merged with the global environment."
@@ -132,6 +134,8 @@ class Context:
         encoding=_UNSET,
         return_result=_UNSET,
         allowed_exit_codes=_UNSET,
+        cancel_timeout=_UNSET,
+        cancel_signal=_UNSET,
     ):
         "Return new context with custom options set."
         kwargs = locals()
@@ -260,6 +264,8 @@ class Command:
         encoding=_UNSET,
         return_result=_UNSET,
         allowed_exit_codes=_UNSET,
+        cancel_timeout=_UNSET,
+        cancel_signal=_UNSET,
     ):
         "Return new command with custom options set."
         kwargs = locals()

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -22,7 +22,7 @@ class Options:  # pylint: disable=too-many-instance-attributes
     "Concrete class for per-command options."
 
     context: "Context" = field(compare=False, repr=False)
-    env: Optional[ImmutableDict] = None
+    env: Optional[ImmutableDict] = field(default=None, repr=False)
     inherit_env: bool = True
     input: Any = b""
     input_close: bool = False
@@ -221,7 +221,7 @@ class Command:
 
         Names longer than 31 characters are truncated.
         """
-        name = self.args[0]
+        name = str(self.args[0])
         if len(name) > 31:
             return f"...{name[-31:]}"
         return name
@@ -308,19 +308,12 @@ class Command:
         return self.options.context._cmd_apply(self, args)
 
     def __str__(self):
-        "Return string representation."
+        """Return string representation for command.
 
-        def _quote(value):
-            value = str(value)
-            if " " in value:
-                return repr(value)
-            return value
-
-        cmd = " ".join(_quote(arg) for arg in self.args)
-        if self.options.env:
-            env = " ".join(f"{k}={_quote(v)}" for k, v in self.options.env.items())
-            return f"{env} {cmd}"
-        return cmd
+        Display the full name of the command only. Don't include arguments or
+        environment variables.
+        """
+        return str(self.args[0])
 
     def __or__(self, rhs):
         "Bitwise or operator is used to build pipelines."

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -618,12 +618,14 @@ def _log_exception(func):
 @_log_exception
 async def _feed_writer(input_bytes, stream):
     if input_bytes:
-        stream.write(input_bytes)
-    try:
-        await stream.drain()
-    except (BrokenPipeError, ConnectionResetError):
-        pass
+        try:
+            stream.write(input_bytes)
+            await stream.drain()
+        except (BrokenPipeError, ConnectionResetError) as ex:
+            LOGGER.info("_feed_writer ex=%r", ex)
+            pass
     stream.close()
+    await stream.wait_closed()  # May raise BrokenPipeError...
 
 
 @_log_exception

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -346,6 +346,9 @@ class Runner:
                 self.proc.returncode if self.proc else "n/a",
                 sys.exc_info()[1],
             )
+            if self.proc and not self.proc._transport.is_closing():
+                LOGGER.warning("Auto-closing transport %r", self.proc._transport)
+                self.proc._transport.close()
 
     async def _cleanup(self, exc_value):
         "Clean up when there is an exception. Return true to suppress exception."

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -269,7 +269,7 @@ class Runner:
 
     async def __aenter__(self):
         "Set up redirections and launch subprocess."
-        LOGGER.info("Runner entering %r", self.name)
+        LOGGER.info("Runner entering %r (%s)", self.name, _sys_info())
         try:
             return await self._setup()
         except (Exception, asyncio.CancelledError) as ex:
@@ -681,3 +681,16 @@ def _close_fds(open_fds):
                 obj.close()
     finally:
         open_fds.clear()
+
+
+def _sys_info():
+    "Return system information for use in logging."
+    import platform
+
+    platform_vers = platform.platform(terse=True)
+    python_impl = platform.python_implementation()
+    python_vers = platform.python_version()
+    running_loop = asyncio.get_running_loop().__class__.__name__
+    child_watcher = asyncio.get_child_watcher().__class__.__name__
+
+    return f"{platform_vers} {python_impl} {python_vers} {running_loop} {child_watcher}"

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -691,6 +691,14 @@ def _sys_info():
     python_impl = platform.python_implementation()
     python_vers = platform.python_version()
     running_loop = asyncio.get_running_loop().__class__.__name__
-    child_watcher = asyncio.get_child_watcher().__class__.__name__
 
-    return f"{platform_vers} {python_impl} {python_vers} {running_loop} {child_watcher}"
+    try:
+        # Child watcher is only implemented on Unix.
+        child_watcher = asyncio.get_child_watcher().__class__.__name__
+    except NotImplementedError:
+        child_watcher = None
+
+    info = f"{platform_vers} {python_impl} {python_vers} {running_loop}"
+    if child_watcher:
+        return f"{info} {child_watcher}"
+    return info

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -457,7 +457,8 @@ class PipeRunner:
 
             return (stdin, stdout, stderr)
 
-        except (Exception, asyncio.CancelledError):
+        except (Exception, asyncio.CancelledError) as ex:
+            LOGGER.warning("Pipeline._setup failed with ex=%r", ex)
             _close_fds(open_fds)
             raise
 

--- a/shellous/util.py
+++ b/shellous/util.py
@@ -82,12 +82,7 @@ async def _gather_collect(aws, return_exceptions=False):
             return [_to_result(task) for task in tasks]
         return [task.result() for task in tasks]
 
-    LOGGER.info(
-        "gather_collect cancelling %d of %d tasks",
-        len(pending),
-        len(tasks),
-        stack_info=True,
-    )
+    LOGGER.info("gather_collect cancelling %d of %d tasks", len(pending), len(tasks))
     await _cancel_wait(pending)
 
     if return_exceptions:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"Configure common fixtures for pytest."
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+async def report_orphan_tasks():
+    "Make sure that all async tests exit with only a single task running."
+    yield
+    tasks = asyncio.all_tasks()
+
+    if len(tasks) > 1:
+        extra_tasks = tasks - {asyncio.current_task()}
+        pytest.fail(f"Orphan tasks still running: {extra_tasks}")
+
+    # We expect the only task to be the current task.
+    assert tasks.pop() is asyncio.current_task()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -59,20 +59,20 @@ def test_apply_noop(sh):
 
 def test_str(sh):
     "Command can be coerced to string."
-    cmd = sh("echo", "-n", "a b")
-    assert str(cmd) == "echo -n 'a b'"
-
-
-def test_str_env(sh):
-    "Command can be coerced to string that includes env details."
-    cmd = sh("echo", "-n", "a b").env(NOOP=1)
-    assert str(cmd) == "NOOP=1 echo -n 'a b'"
+    cmd = sh("/bin/echo", "-n", "secret").env(SECRET=42)
+    assert str(cmd) == "/bin/echo"
 
 
 def test_repr(sh):
     "Command supplies a __repr__ implementation."
-    cmd = sh("echo", "-n", "a b")
-    assert repr(cmd).startswith("Command(args=('echo', '-n', 'a b'), options=Options(")
+    cmd = sh("echo", "-n", "secret_arg").env(SECRET=42)
+    result = repr(cmd)
+    assert result.startswith(
+        "Command(args=('echo', '-n', 'secret_arg'), options=Options("
+    )
+
+    # Env vars are not included in output for security reasons.
+    assert "SECRET" not in result
 
 
 def test_non_existant(sh):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -176,3 +176,26 @@ def test_pipeline_call(sh):
     assert pipe() is pipe  # no args is okay
     with pytest.raises(TypeError):
         pipe("foo")
+
+
+@pytest.mark.xfail(reason="FIXME")
+def test_invalid_pipeline_override_stdout(sh):
+    """A Pipeline should not override existing stdout redirections."""
+    echo = sh("echo").stdout("/tmp/tmp_file")
+    with pytest.raises(ValueError):
+        echo | sh("grep")
+
+
+@pytest.mark.xfail(reason="FIXME")
+def test_invalid_pipeline_override_stdin(sh):
+    """A Pipeline should not override existing stdin redirections."""
+    grep = sh("grep").stdin("/tmp/tmp_file")
+    with pytest.raises(ValueError):
+        sh("echo") | grep
+
+
+@pytest.mark.xfail(reason="FIXME")
+def test_invalid_pipeline_operators(sh):
+    "Test >> in the middle of a pipeline."
+    with pytest.raises(ValueError):
+        sh("echo") >> "/tmp/tmp_file" | sh("cat")

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -61,7 +61,7 @@ sys.exit(SHELLOUS_EXIT_CODE)
 """
 
 
-_CANCELLED_EXIT_CODE = -9 if sys.platform != "win32" else 1
+_CANCELLED_EXIT_CODE = -15 if sys.platform != "win32" else 1
 
 
 @pytest.fixture

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -10,19 +10,29 @@ from shellous import CAPTURE, INHERIT, PipeResult, Result, ResultError, context
 pytestmark = pytest.mark.asyncio
 
 
+# 4MB + 1: Much larger than necessary.
+# See https://github.com/python/cpython/blob/main/Lib/test/support/__init__.py
+PIPE_MAX_SIZE = 4 * 1024 * 1024 + 1
+
+
 def test_debug_mode(event_loop):
     "Tests should be running on a loop with asyncio debug mode set."
     assert event_loop.get_debug()
 
 
 @pytest.fixture
-def python_script():
+def sh():
+    "Create a default shellous context."
+    return context()
+
+
+@pytest.fixture
+def python_script(sh):
     """Create a python script that can be used in tests.
 
     The script behaves like common versions of `echo`, `cat`, `sleep` or `env`
     depending on environment variables.
     """
-    sh = context()
     return sh(sys.executable, "-c", _SCRIPT)
 
 
@@ -239,3 +249,13 @@ async def test_pipe_redirect_stdin_capture(cat_cmd, tr_cmd):
     cmd = cat_cmd | tr_cmd
     with pytest.raises(ValueError, match="multiple capture requires 'async with'"):
         await cmd.stdin(CAPTURE)
+
+
+async def test_broken_pipe(sh):
+    "Test broken pipe error for large data passed to stdin."
+
+    data = b"b" * PIPE_MAX_SIZE
+    cmd = sh(sys.executable, "-c", "pass")
+
+    with pytest.raises(BrokenPipeError):
+        await cmd.stdin(data)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -61,3 +61,13 @@ async def test_gather_collect_return_exceptions():
     assert isinstance(result[0], ValueError)
     assert result[0].args[0] == 7
     assert result[1] == 99
+
+
+async def test_gather_collect_timeout():
+    "Test the `gather_collect` function with a timeout."
+
+    async def _coro():
+        await asyncio.sleep(60.0)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await gather_collect(_coro(), _coro(), timeout=0.1)

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -607,3 +607,24 @@ async def test_cancel_timeout(sh):
     )
     with pytest.raises(ResultError):
         await asyncio.wait_for(sleep(10.0), 0.25)
+
+
+async def test_shell_cmd(sh):
+    "Test a shell command.  (https://bugs.python.org/issue43884)"
+    shell = sh("/bin/sh", "-c").set(
+        return_result=True,
+        allowed_exit_codes={0, _CANCELLED_EXIT_CODE},
+    )
+
+    task = shell("sleep 2 && echo done").task()
+    await asyncio.sleep(0.25)
+    task.cancel()
+
+    result = await task
+    assert result == Result(
+        output_bytes=None,
+        exit_code=_CANCELLED_EXIT_CODE,
+        cancelled=True,
+        encoding="utf-8",
+        extra=None,
+    )

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -3,6 +3,7 @@
 import asyncio
 import io
 import os
+import signal
 import sys
 
 import pytest
@@ -594,3 +595,13 @@ async def test_multiple_capture(sh):
     result = runner.result(output)
 
     assert result == "abc\n"
+
+
+async def test_cancel_timeout(sh):
+    "Test the `cancel_timeout` setting."
+    sleep = sh("nohup", "sleep").set(
+        cancel_timeout=0.1,
+        cancel_signal=signal.SIGHUP,
+    )
+    with pytest.raises(ResultError):
+        await asyncio.wait_for(sleep(5.0), 2.0)

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -600,8 +600,8 @@ async def test_multiple_capture(sh):
 async def test_cancel_timeout(sh):
     "Test the `cancel_timeout` setting."
     sleep = sh("nohup", "sleep").set(
-        cancel_timeout=0.1,
+        cancel_timeout=0.25,
         cancel_signal=signal.SIGHUP,
     )
     with pytest.raises(ResultError):
-        await asyncio.wait_for(sleep(5.0), 2.0)
+        await asyncio.wait_for(sleep(10.0), 0.25)

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -22,6 +22,8 @@ from shellous.util import gather_collect
 unix_only = pytest.mark.skipif(sys.platform == "win32", reason="Unix")
 pytestmark = [pytest.mark.asyncio, unix_only]
 
+_CANCELLED_EXIT_CODE = -15
+
 
 @pytest.fixture
 def sh():
@@ -159,7 +161,7 @@ async def test_timeout_fail(sh):
     assert exc_info.type is ResultError
     assert exc_info.value.result == Result(
         output_bytes=None,
-        exit_code=-9,
+        exit_code=_CANCELLED_EXIT_CODE,
         cancelled=True,
         encoding="utf-8",
         extra=None,
@@ -174,7 +176,7 @@ async def test_timeout_fail_no_capturing(sh):
 
     assert exc_info.value.result == Result(
         output_bytes=None,
-        exit_code=-9,
+        exit_code=_CANCELLED_EXIT_CODE,
         cancelled=True,
         encoding="utf-8",
         extra=None,


### PR DESCRIPTION
- Implement cancel_timeout and cancel_signal options.
- Add CI for Python 3.10-dev.
- Include timestamps in CI test logging.
- Option __repr__ no longer includes env vars.
- Command __str__ no longer includes args or env vars.
- Runner task names are tagged with the name of the fd redirected.
- Runner logs include info about the platform and asyncio event loop.
- Fix support for BrokenPipeError.
- Make sure subprocess transport is closed.