### PR TITLE
Change API for async with

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To redirect stdin using a file's contents, use a `Path` object from `pathlib`.
 >>> from pathlib import Path
 >>> cmd = Path("README.md") | sh("wc", "-l")
 >>> await cmd
-'     210\n'
+'     209\n'
 ```
 
 [More on redirection...](docs/redirection.md)
@@ -201,9 +201,8 @@ You can use `async with` to interact with the process streams directly. You have
 are responsible for correctly reading and writing multiple streams at the same time.
 
 ```python-repl
->>> runner = pipe.runner()
->>> async with runner as (stdin, stdout, stderr):
-...   data = await stdout.readline()
+>>> async with pipe.run() as run:
+...   data = await run.stdout.readline()
 ...   print(data)
 ... 
 b'README.md\n'

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -361,15 +361,14 @@ class Command:
             name=f"{self.name}-{id(self)}",
         )
 
-    def runner(self):
+    def run(self):
         """Return a `Runner` to run the process incrementally.
 
         ```
-        runner = cmd.runner()
-        async with runner as (stdin, stdout, stderr):
-            # do something with stdin, stdout, stderr...
-            # close stdin to signal we're done...
-        result = runner.result()
+        async with cmd.run() as run:
+            # do something with run.stdin, run.stdout, run.stderr...
+            # close run.stdin to signal we're done...
+        result = run.result()
         ```
         """
         return Runner(self)

--- a/shellous/pipeline.py
+++ b/shellous/pipeline.py
@@ -54,15 +54,14 @@ class Pipeline:
             name=f"{self.name}-{id(self)}",
         )
 
-    def runner(self):
-        """Return a `Runner` to help run the process incrementally.
+    def run(self):
+        """Return a `Runner` to help run the pipeline incrementally.
 
         ```
-        runner = pipe.runner()
-        async with runner as (stdin, stdout, stderr):
-            # do something with stdin, stdout, stderr...
+        async with pipe.run() as run:
+            # do something with run.stdin, run.stdout, run.stderr...
             # close stdin to signal we're done...
-        result = runner.result()
+        result = run.result()
         ```
         """
         return PipeRunner(self, capturing=True)

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -63,8 +63,7 @@ async def run_asyncio_repl(cmds):
         .env(**_current_env())
     )
 
-    runner = repl.runner()
-    async with runner as run:
+    async with repl.run() as run:
         p = Prompt(run.stdin, run.stdout, errbuf)
         await p.prompt()
 
@@ -74,7 +73,7 @@ async def run_asyncio_repl(cmds):
 
         run.stdin.close()
 
-    result = runner.result()
+    result = run.result()
     assert result.exit_code == 0
     return output
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -128,9 +128,8 @@ def test_parse_readme():
         'pipe = sh("ls") | sh("grep", "README")',
         "await pipe",
         "async for line in pipe:\n  print(line.rstrip())\n",
-        "runner = pipe.runner()",
-        "async with runner as (stdin, stdout, stderr):\n"
-        "  data = await stdout.readline()\n"
+        "async with pipe.run() as run:\n"
+        "  data = await run.stdout.readline()\n"
         "  print(data)\n",
     ]
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -64,15 +64,15 @@ async def run_asyncio_repl(cmds):
     )
 
     runner = repl.runner()
-    async with runner as (stdin, stdout, _stderr):
-        p = Prompt(stdin, stdout, errbuf)
+    async with runner as run:
+        p = Prompt(run.stdin, run.stdout, errbuf)
         await p.prompt()
 
         output = []
         for cmd in cmds:
             output.append(await p.prompt(cmd))
 
-        stdin.close()
+        run.stdin.close()
 
     result = runner.result()
     assert result.exit_code == 0

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -324,10 +324,10 @@ async def test_stdout_deadlock_antipattern(bulk_cmd):
 
     async def _antipattern():
         runner = bulk_cmd.runner()
-        async with runner as (stdin, stdout, stderr):
-            assert stdin is None
-            assert stderr is None
-            assert stdout is not None
+        async with runner as run:
+            assert run.stdin is None
+            assert run.stderr is None
+            assert run.stdout
             # ... and we don't read from stdout at all.
 
     with pytest.raises(asyncio.TimeoutError):

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -323,8 +323,7 @@ async def test_stdout_deadlock_antipattern(bulk_cmd):
     "Use async-with but don't read from stdout."
 
     async def _antipattern():
-        runner = bulk_cmd.runner()
-        async with runner as run:
+        async with bulk_cmd.run() as run:
             assert run.stdin is None
             assert run.stderr is None
             assert run.stdout
@@ -339,10 +338,9 @@ async def test_runner_enter(echo_cmd):
     "Test cancellation behavior in Runner.__aenter__."
 
     async def test_task():
-        runner = echo_cmd.runner()
-        async with runner as _:
+        async with echo_cmd.run() as run:
             pass
-        return runner.result()
+        return run.result()
 
     task = asyncio.create_task(test_task())
     await asyncio.sleep(0)

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -401,13 +401,13 @@ async def test_async_context_manager(sh):
     "Use `async with` to read/write bytes incrementally."
     tr = sh("tr", "[:lower:]", "[:upper:]").stdin(CAPTURE)
 
-    async with tr.runner() as (stdin, stdout, stderr):
-        assert stderr is None
+    async with tr.runner() as run:
+        assert run.stderr is None
 
         # N.B. We won't deadlock writing/reading a single byte.
-        stdin.write(b"a")
-        stdin.close()
-        result = await stdout.read()
+        run.stdin.write(b"a")
+        run.stdin.close()
+        result = await run.stdout.read()
 
     assert result == b"A"
 
@@ -597,11 +597,11 @@ async def test_multiple_capture(sh):
     cmd = sh("cat").stdin(CAPTURE)
 
     runner = cmd.runner()
-    async with runner as (stdin, stdout, _stderr):
-        stdin.write(b"abc\n")
-        output, _ = await asyncio.gather(stdout.readline(), stdin.drain())
+    async with runner as run:
+        run.stdin.write(b"abc\n")
+        output, _ = await asyncio.gather(run.stdout.readline(), run.stdin.drain())
 
-        stdin.close()
+        run.stdin.close()
     result = runner.result(output)
 
     assert result == "abc\n"

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -506,13 +506,13 @@ async def test_pipeline_async_context_manager(sh):
     "Use `async with` to read/write bytes incrementally."
     tr = sh("tr", "[:lower:]", "[:upper:]")
     pipe = (tr | sh("cat")).stdin(CAPTURE)
-    async with pipe.runner() as (stdin, stdout, stderr):
-        assert stderr is None
+    async with pipe.run() as run:
+        assert run.stderr is None
 
         # N.B. We won't deadlock writing/reading a single byte.
-        stdin.write(b"a")
-        stdin.close()
-        result = await stdout.read()
+        run.stdin.write(b"a")
+        run.stdin.close()
+        result = await run.stdout.read()
 
     assert result == b"A"
 

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -401,7 +401,7 @@ async def test_async_context_manager(sh):
     "Use `async with` to read/write bytes incrementally."
     tr = sh("tr", "[:lower:]", "[:upper:]").stdin(CAPTURE)
 
-    async with tr.runner() as run:
+    async with tr.run() as run:
         assert run.stderr is None
 
         # N.B. We won't deadlock writing/reading a single byte.
@@ -596,14 +596,12 @@ async def test_multiple_capture(sh):
     "Test the multiple capture example from the documentation."
     cmd = sh("cat").stdin(CAPTURE)
 
-    runner = cmd.runner()
-    async with runner as run:
+    async with cmd.run() as run:
         run.stdin.write(b"abc\n")
         output, _ = await asyncio.gather(run.stdout.readline(), run.stdin.drain())
-
         run.stdin.close()
-    result = runner.result(output)
 
+    result = run.result(output)
     assert result == "abc\n"
 
 


### PR DESCRIPTION
- "async with" now returns the runner instance instead of returning (stdin, stdout, stderr).
- Renamed "runner()" method to "run()".