### PR TITLE
Add iter() method to Command.

### DIFF
--- a/shellous/command.py
+++ b/shellous/command.py
@@ -15,7 +15,7 @@ from typing import Any, Optional
 from immutables import Map as ImmutableDict
 
 from shellous.redirect import Redirect
-from shellous.runner import Runner, run, run_iter
+from shellous.runner import Runner, run_cmd, run_cmd_iter
 from shellous.util import coerce_env
 
 # Sentinel used in "mergable" keyword arguments to indicate that a value
@@ -354,10 +354,10 @@ class Command:
         del kwargs["self"]
         return Command(self.args, self.options.set(kwargs))
 
-    def task(self, *, _streams_future=None):
+    def task(self, *, _run_future=None):
         "Wrap the command in a new asyncio task."
         return asyncio.create_task(
-            run(self, _streams_future=_streams_future),
+            run_cmd(self, _run_future=_run_future),
             name=f"{self.name}-{id(self)}",
         )
 
@@ -375,11 +375,11 @@ class Command:
 
     def __await__(self):
         "Run process and return the standard output."
-        return run(self).__await__()
+        return run_cmd(self).__await__()
 
     def __aiter__(self):
         "Return an asynchronous iterator over the standard output."
-        return run_iter(self)
+        return run_cmd_iter(self)
 
     def __call__(self, *args):
         "Apply more arguments to the end of the command."

--- a/shellous/harvest.py
+++ b/shellous/harvest.py
@@ -4,9 +4,13 @@ import asyncio
 
 from shellous.log import LOGGER
 
+_CANCEL_TIMEOUT = 1.0  # seconds to wait for cancelled task to finish
+
 
 async def harvest(*aws, timeout=None, trustee=None):
     """Run a bunch of awaitables as tasks. Do not return results.
+
+    After the harvest returns, all of the awaitables are guaranteed to be done.
 
     Raises first exception seen, or just returns normally.
 
@@ -33,6 +37,8 @@ async def harvest(*aws, timeout=None, trustee=None):
 async def harvest_results(*aws, timeout=None, trustee=None):
     """Run a bunch of awaitables as tasks and return the results.
 
+    After the harvest returns, all of the awaitables are guaranteed to be done.
+
     Exceptions are included in the result list, including CancelledError.
 
     Similar to `asyncio.gather` with `return_exceptions` with one difference:
@@ -54,6 +60,8 @@ async def harvest_results(*aws, timeout=None, trustee=None):
 
 async def harvest_wait(tasks, *, timeout=None, trustee=None):
     """Wait for tasks to finish or raise an exception.
+
+    After the harvest returns, all of the tasks are guaranteed to be done.
 
     If there are pending tasks, they are cancelled and collected. Their
     exceptions are not consumed.
@@ -109,7 +117,7 @@ async def _cancel_wait(tasks, trustee):
 
         _, pending = await asyncio.wait(
             tasks,
-            timeout=1.0,
+            timeout=_CANCEL_TIMEOUT,
             return_when=asyncio.ALL_COMPLETED,
         )
 

--- a/shellous/pipeline.py
+++ b/shellous/pipeline.py
@@ -31,6 +31,11 @@ class Pipeline:
         "Return last command's options."
         return self.commands[-1].options
 
+    @property
+    def multiple_capture(self):
+        "Return true if pipe uses multiple capture."
+        return any(cmd.multiple_capture for cmd in self.commands)
+
     def stdin(self, input_):
         "Set stdin on the first command of the pipeline."
         if not self.commands:

--- a/shellous/redirect.py
+++ b/shellous/redirect.py
@@ -22,6 +22,7 @@ class Redirect(enum.IntEnum):
 
 @log_method(True)
 async def write_stream(input_bytes, stream):
+    "Write input_bytes to stream."
     try:
         if input_bytes:
             stream.write(input_bytes)
@@ -36,6 +37,7 @@ async def write_stream(input_bytes, stream):
 
 @log_method(True)
 async def copy_stringio(source, dest, encoding):
+    "Copy bytes from source stream to dest StringIO."
     # Collect partial reads into a BytesIO.
     buf = io.BytesIO()
     try:
@@ -52,6 +54,7 @@ async def copy_stringio(source, dest, encoding):
 
 @log_method(True)
 async def copy_bytesio(source, dest):
+    "Copy bytes from source stream to dest BytesIO."
     # Collect partial reads into a BytesIO.
     while True:
         data = await source.read(1024)
@@ -62,6 +65,7 @@ async def copy_bytesio(source, dest):
 
 @log_method(True)
 async def copy_bytearray(source, dest):
+    "Copy bytes from source stream to dest bytearray."
     # Collect partial reads into a bytearray.
     while True:
         data = await source.read(1024)

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -513,7 +513,7 @@ class PipeRunner:
 
             return self
 
-        except BaseException:
+        except BaseException:  # pylint: disable=broad-except
             # Clean up after any exception *including* CancelledError.
             close_fds(open_fds)
 

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -625,6 +625,9 @@ async def run_pipe(pipe):
 
 async def run_pipe_iter(pipe):
     "Run a pipeline and iterate over its output lines."
+    if pipe.multiple_capture:
+        raise ValueError("multiple capture requires 'async with'")
+
     run = PipeRunner(pipe, capturing=True)
     async with run:
         assert run.stdin is None

--- a/shellous/util.py
+++ b/shellous/util.py
@@ -109,3 +109,19 @@ def platform_info():
     if child_watcher:
         return f"{info} {child_watcher}"
     return info
+
+
+def close_fds(open_fds):
+    "Close open file descriptors or file objects."
+    try:
+        for obj in open_fds:
+            if isinstance(obj, int):
+                if obj >= 0:
+                    try:
+                        os.close(obj)
+                    except OSError:
+                        pass
+            else:
+                obj.close()
+    finally:
+        open_fds.clear()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,5 +1,7 @@
 "Unit tests for the Command class."
 
+# pylint: disable=redefined-outer-name,invalid-name
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,3 +1,7 @@
+"Unit tests for Pipeline class."
+
+# pylint: disable=redefined-outer-name,invalid-name
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -158,8 +158,8 @@ def _parse_readme(filename):
         data = afile.read()
 
     # Make a list of all the python-repl code blocks in the file.
-    PYTHON_REPL = re.compile(r"\n```python-repl\n(.+?)```\n", re.DOTALL)
-    blocks = [m.group(1) for m in PYTHON_REPL.finditer(data)]
+    _PYTHON_REPL = re.compile(r"\n```python-repl\n(.+?)```\n", re.DOTALL)
+    blocks = [m.group(1) for m in _PYTHON_REPL.finditer(data)]
 
     # Break each block into lines.
     lines = []

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -1,5 +1,7 @@
 "Shellous cross-platform tests."
 
+# pylint: disable=redefined-outer-name,invalid-name
+
 import asyncio
 import hashlib
 import io
@@ -11,7 +13,6 @@ from shellous import CAPTURE, DEVNULL, INHERIT, PipeResult, Result, ResultError,
 from shellous.harvest import harvest_results
 
 pytestmark = pytest.mark.asyncio
-
 
 # 4MB + 1: Much larger than necessary.
 # See https://github.com/python/cpython/blob/main/Lib/test/support/__init__.py
@@ -413,3 +414,18 @@ async def test_pipe_immediate_cancel(cat_cmd, tr_cmd):
     with pytest.raises(asyncio.CancelledError):
         # FIXME: Should raise ResultError.
         await task
+
+
+async def test_breaking_out_of_async_iter(env_cmd):
+    "Test breaking out of an async iterator."
+    async with env_cmd.iter() as iter:
+        async for _ in iter:
+            break
+
+
+async def test_exception_in_async_iter(env_cmd):
+    "Test breaking out of an async iterator."
+    with pytest.raises(ValueError):
+        async with env_cmd.iter() as iter:
+            async for _ in iter:
+                raise ValueError(1)

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -387,3 +387,18 @@ async def test_many_short_programs_parallel(echo_cmd):
     results = await harvest_results(*cmds)
 
     assert results == ["abcd"] * COUNT
+
+
+async def test_redirect_stdin_capture_iter(cat_cmd, tr_cmd):
+    "Test setting stdin to CAPTURE when using `async for`."
+    with pytest.raises(ValueError, match="multiple capture requires 'async with'"):
+        async for line in cat_cmd.stdin(CAPTURE):
+            pass
+
+
+async def test_pipe_redirect_stdin_capture_iter(cat_cmd, tr_cmd):
+    "Test setting stdin on pipe to CAPTURE when using `async for`."
+    cmd = cat_cmd | tr_cmd
+    with pytest.raises(ValueError, match="multiple capture requires 'async with'"):
+        async for line in cmd.stdin(CAPTURE):
+            pass

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -402,3 +402,14 @@ async def test_pipe_redirect_stdin_capture_iter(cat_cmd, tr_cmd):
     with pytest.raises(ValueError, match="multiple capture requires 'async with'"):
         async for line in cmd.stdin(CAPTURE):
             pass
+
+
+async def test_pipe_immediate_cancel(cat_cmd, tr_cmd):
+    "Test running a pipe that is immediately cancelled."
+    cmd = cat_cmd | tr_cmd
+    task = cmd.task()
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        # FIXME: Should raise ResultError.
+        await task

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -274,21 +274,7 @@ async def test_broken_pipe_in_pipeline(cat_cmd, echo_cmd):
         await (data | cat_cmd | echo_cmd("abc"))
 
 
-def _latent_bug():
-    """There is a latent bug. This test...
-
-    1. Sometimes fails on Windows with a timeout in wait_closed.
-    2. Sometimes fails on Unix/MacOS with a FastChildWatcher.
-    """
-    import os
-
-    return (
-        sys.platform == "win32"
-        or os.environ.get("SHELLOUS_CHILDWATCHER_TYPE") == "fast"
-    )
-
-
-@pytest.mark.xfail(_latent_bug(), reason="latent bug")
+@pytest.mark.xfail(True, reason="latent bug")
 async def test_broken_pipe_in_failed_pipeline(cat_cmd, echo_cmd):
     "Test broken pipe error within a pipeline; last command fails."
     data = b"c" * PIPE_MAX_SIZE

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 import pytest
-from shellous.util import coerce_env, decode, log_method
+from shellous.util import close_fds, coerce_env, decode, log_method
 
 pytestmark = pytest.mark.asyncio
 
@@ -70,3 +70,15 @@ def test_coerce_env():
     else:
         result = coerce_env(dict(PATH=...))
         assert result == {"PATH": os.environ["PATH"]}
+
+
+def test_close_fds(tmp_path):
+    "Test the close_fds() function."
+    out = tmp_path / "test_close_fds"
+
+    with open(out, "w") as fp:
+        fd = fp.fileno()
+        open_files = [fp, fd]
+
+    close_fds(open_files)
+    assert not open_files

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -515,6 +515,12 @@ async def test_pipeline_async_context_manager(sh):
         result = await run.stdout.read()
 
     assert result == b"A"
+    assert run.name == "tr|cat"
+    assert (
+        repr(run) == "<PipeRunner 'tr|cat' results=["
+        "Result(output_bytes=None, exit_code=0, cancelled=False, encoding='utf-8', extra=None), "
+        "Result(output_bytes=None, exit_code=0, cancelled=False, encoding='utf-8', extra=None)]>"
+    )
 
 
 async def test_gather_same_cmd(sh):


### PR DESCRIPTION
Test use of iter() method in Command.
Pylint and mypy fixes.
Rename run() methods.