### PR TITLE
Redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ By default, standard error is not captured. To redirect standard error, use the 
 method.
 
 ```pycon
->>> cmd = sh("cat", "does_not_exist").stderr(shellous.STDOUT)
+>>> cmd = sh("cat", "does_not_exist").stderr(sh.STDOUT)
 >>> await cmd.set(exit_codes={0,1})
 'cat: does_not_exist: No such file or directory\n'
 ```
@@ -153,7 +153,7 @@ To redirect standard error to the hosting program's `sys.stderr`, use the INHERI
 option.
 
 ```pycon
->>> cmd = sh("cat", "does_not_exist").stderr(shellous.INHERIT)
+>>> cmd = sh("cat", "does_not_exist").stderr(sh.INHERIT)
 >>> await cmd
 cat: does_not_exist: No such file or directory
 Traceback (most recent call last):
@@ -189,7 +189,7 @@ Use `.writable` to write to a command instead.
 
 ```pycon
 >>> buf = bytearray()
->>> cmd = sh("ls") | sh("tee", sh("grep", "README").writable | buf) | shellous.DEVNULL
+>>> cmd = sh("ls") | sh("tee", sh("grep", "README").writable | buf) | sh.DEVNULL
 >>> await cmd
 ''
 >>> buf

--- a/docs/redirection.md
+++ b/docs/redirection.md
@@ -9,12 +9,12 @@ Redirection Constants
 
 shellous defines several redirection constants that you can use:
 
-| Constant | Literal Form | What is does... |
-| -------- | ------------ | --------------- |
-| DEVNULL  | `None` | Reads/writes to special file `/dev/null`. |
-| CAPTURE  | `()`   | Pipe input/output to current Python process. |
-| INHERIT  | `...`  | Inherit stdin/stdout/stderr from current Python process. |
-| STDOUT   | `1`    | Write standard error to same place as standard output. |
+| Constant | What is does... |
+| -------- | --------------- |
+| DEVNULL  | Reads/writes to special file `/dev/null`. |
+| CAPTURE  | Pipe input/output to current Python process. |
+| INHERIT  | Inherit stdin/stdout/stderr from current Python process. |
+| STDOUT   | Write standard error to same place as standard output. |
 
 
 Standard Input

--- a/shellous/__init__.py
+++ b/shellous/__init__.py
@@ -17,10 +17,11 @@ from .runner import AUDIT_EVENT_SUBPROCESS_SPAWN  # noqa: F401
 if sys.platform != "win32":
     from .watcher import DefaultChildWatcher  # noqa: F401
 
-STDOUT = Redirect.STDOUT
-DEVNULL = Redirect.DEVNULL
-CAPTURE = Redirect.CAPTURE
-INHERIT = Redirect.INHERIT
+if False:
+    STDOUT = Redirect.STDOUT
+    DEVNULL = Redirect.DEVNULL
+    CAPTURE = Redirect.CAPTURE
+    INHERIT = Redirect.INHERIT
 
 
 def context() -> CmdContext:

--- a/shellous/__init__.py
+++ b/shellous/__init__.py
@@ -1,7 +1,7 @@
 """
 .. include:: ../README.md
 """
-__docformat__ = "restructuredtext"
+
 __version__ = "0.16.0"
 
 import sys
@@ -10,20 +10,13 @@ import sys
 from .command import CmdContext, Command, Options  # noqa: F401
 from .pipeline import Pipeline  # noqa: F401
 from .pty_util import cbreak, cooked, raw  # noqa: F401
-from .redirect import Redirect
 from .result import PipeResult, Result, ResultError  # noqa: F401
 from .runner import AUDIT_EVENT_SUBPROCESS_SPAWN  # noqa: F401
 
 if sys.platform != "win32":
     from .watcher import DefaultChildWatcher  # noqa: F401
 
-if False:
-    STDOUT = Redirect.STDOUT
-    DEVNULL = Redirect.DEVNULL
-    CAPTURE = Redirect.CAPTURE
-    INHERIT = Redirect.INHERIT
-
-
+# TODO: This function is deprecated; do not use.
 def context() -> CmdContext:
     "Construct a new execution context."
     import warnings
@@ -34,3 +27,9 @@ def context() -> CmdContext:
 
 sh = CmdContext()
 "Default execution context. Immutable."
+
+# TODO: These aliases here are deprecated; use the sh.CONSTANT forms.
+STDOUT = sh.STDOUT
+DEVNULL = sh.DEVNULL
+CAPTURE = sh.CAPTURE
+INHERIT = sh.INHERIT

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -12,7 +12,7 @@ import os
 import signal
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, TypeVar, Union
+from typing import Any, Callable, ClassVar, Optional, TypeVar, Union
 
 from immutables import Map as ImmutableDict
 
@@ -183,6 +183,18 @@ class Options:  # pylint: disable=too-many-instance-attributes
 @dataclass(frozen=True)
 class CmdContext:
     """Concrete class for an immutable execution context."""
+
+    CAPTURE: ClassVar[Redirect] = Redirect.CAPTURE
+    "Capture and read/write stream manually."
+
+    DEVNULL: ClassVar[Redirect] = Redirect.DEVNULL
+    "Redirect to /dev/null."
+
+    INHERIT: ClassVar[Redirect] = Redirect.INHERIT
+    "Redirect to same place as existing stdin/stderr/stderr."
+
+    STDOUT: ClassVar[Redirect] = Redirect.STDOUT
+    "Redirect stderr to same place as stdout."
 
     options: Options = Options()
     "Default command options."

--- a/shellous/redirect.py
+++ b/shellous/redirect.py
@@ -4,6 +4,7 @@ import asyncio
 import enum
 import io
 import os
+import warnings
 from logging import Logger
 from typing import Optional
 
@@ -45,9 +46,20 @@ class Redirect(enum.IntEnum):
     @staticmethod
     def from_literal(literal, is_stderr=False):
         "Return object with literal values replaced by Redirect constant."
+
+        if isinstance(literal, (tuple, type(...), type(None))):
+            warnings.warn(
+                f"literal {literal!r} is no longer supported",
+                DeprecationWarning,
+            )
+
         # For stderr, the literal `1` indicates that stderr is redirected to
         # the same place as STDOUT.
         if is_stderr and isinstance(literal, int) and literal == 1:
+            warnings.warn(
+                f"stderr literal {literal!r} is no longer supported",
+                DeprecationWarning,
+            )
             return Redirect.STDOUT
 
         try:

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -246,7 +246,7 @@ def test_percent_op():
     "Test the percent/modulo operator for concatenation."
 
     nohup = sh("nohup").stdin("abc")
-    echo = sh("echo", "hello").stdout(...)
+    echo = sh("echo", "hello").stdout(sh.INHERIT)
 
     # Note that the concatenated command is a new command with default
     # redirections and settings (from the lhs context)
@@ -258,7 +258,7 @@ def test_percent_op_multiple():
     "Test the percent/modulo operator for concatenation."
 
     nohup = sh("nohup").stdin("abc")
-    echo = sh("echo", "hello").stdout(...)
+    echo = sh("echo", "hello").stdout(sh.INHERIT)
 
     assert nohup % echo % nohup == nohup(echo(nohup.args).args)
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=redefined-outer-name,invalid-name
 
+import dataclasses
 import pickle
 from pathlib import Path
 
@@ -302,3 +303,55 @@ def test_command_pickle_callback():
 
     with pytest.raises((pickle.PicklingError, AttributeError)):
         pickle.dumps(cmd)
+
+
+def test_dataclasses():
+    """Test that data classes have the expected fields.
+
+    Check that class variables don't appear here.
+    """
+
+    ctxt_fields = [field.name for field in dataclasses.fields(sh)]
+    assert sorted(ctxt_fields) == ["options"]
+
+    cmd_fields = [field.name for field in dataclasses.fields(sh("echo"))]
+    assert sorted(cmd_fields) == ["args", "options"]
+
+    opt_fields = [field.name for field in dataclasses.fields(sh.options)]
+    assert sorted(opt_fields) == [
+        "_preexec_fn",
+        "_start_new_session",
+        "alt_name",
+        "audit_callback",
+        "cancel_signal",
+        "cancel_timeout",
+        "close_fds",
+        "encoding",
+        "env",
+        "error",
+        "error_append",
+        "error_close",
+        "exit_codes",
+        "incomplete_result",
+        "inherit_env",
+        "input",
+        "input_close",
+        "output",
+        "output_append",
+        "output_close",
+        "pass_fds",
+        "pass_fds_close",
+        "pty",
+        "return_result",
+        "timeout",
+        "writable",
+    ]
+
+
+def test_context_enums():
+    "Test that `sh` defines the important Redirect enums."
+
+    assert sh.CAPTURE.name == "CAPTURE"
+    assert sh.DEVNULL.name == "DEVNULL"
+    assert sh.INHERIT.name == "INHERIT"
+    assert sh.STDOUT.name == "STDOUT"

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 from immutables import Map as ImmutableDict
-from shellous import DEVNULL, sh
+from shellous import sh
 from shellous.command import Options
 
 
@@ -227,7 +227,7 @@ def test_arg_checks_append():
         echo.stdout(7, append=True)  # 7 is file descriptor
 
     with pytest.raises(TypeError, match="append"):
-        echo.stdout(DEVNULL, append=True)
+        echo.stdout(sh.DEVNULL, append=True)
 
 
 def test_replace_args_method():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -243,38 +243,44 @@ def test_pipeline_len_getitem():
 
 def test_pipeline_redirect_none_stdin():
     "Test use of None in pipeline."
-    cmd = None | sh("echo")
-    assert cmd == sh("echo").stdin(sh.DEVNULL)
+    with pytest.deprecated_call():
+        cmd = None | sh("echo")
+        assert cmd == sh("echo").stdin(sh.DEVNULL)
 
 
 def test_pipeline_redirect_none_stdout():
     "Test use of None in pipeline."
-    cmd = sh("echo") | None
-    assert cmd == sh("echo").stdout(sh.DEVNULL)
+    with pytest.deprecated_call():
+        cmd = sh("echo") | None
+        assert cmd == sh("echo").stdout(sh.DEVNULL)
 
 
 def test_pipeline_redirect_ellipsis_stdin():
     "Test use of Ellipsis in pipeline."
-    cmd = ... | sh("echo")
-    assert cmd == sh("echo").stdin(sh.INHERIT)
+    with pytest.deprecated_call():
+        cmd = ... | sh("echo")
+        assert cmd == sh("echo").stdin(sh.INHERIT)
 
 
 def test_pipeline_redirect_ellipsis_stdout():
     "Test use of Ellipsis in pipeline."
-    cmd = sh("echo") | ...
-    assert cmd == sh("echo").stdout(sh.INHERIT)
+    with pytest.deprecated_call():
+        cmd = sh("echo") | ...
+        assert cmd == sh("echo").stdout(sh.INHERIT)
 
 
 def test_pipeline_redirect_tuple_stdin():
     "Test use of empty tuple in pipeline."
-    cmd = () | sh("echo")
-    assert cmd == sh("echo").stdin(sh.CAPTURE)
+    with pytest.deprecated_call():
+        cmd = () | sh("echo")
+        assert cmd == sh("echo").stdin(sh.CAPTURE)
 
 
 def test_pipeline_redirect_tuple_stdout():
     "Test use of empty tuple in pipeline."
-    cmd = sh("echo") | ()
-    assert cmd == sh("echo").stdout(sh.CAPTURE)
+    with pytest.deprecated_call():
+        cmd = sh("echo") | ()
+        assert cmd == sh("echo").stdout(sh.CAPTURE)
 
 
 def test_pipeline_percent_op():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -244,37 +244,37 @@ def test_pipeline_len_getitem():
 def test_pipeline_redirect_none_stdin():
     "Test use of None in pipeline."
     cmd = None | sh("echo")
-    assert cmd == sh("echo").stdin(shellous.DEVNULL)
+    assert cmd == sh("echo").stdin(sh.DEVNULL)
 
 
 def test_pipeline_redirect_none_stdout():
     "Test use of None in pipeline."
     cmd = sh("echo") | None
-    assert cmd == sh("echo").stdout(shellous.DEVNULL)
+    assert cmd == sh("echo").stdout(sh.DEVNULL)
 
 
 def test_pipeline_redirect_ellipsis_stdin():
     "Test use of Ellipsis in pipeline."
     cmd = ... | sh("echo")
-    assert cmd == sh("echo").stdin(shellous.INHERIT)
+    assert cmd == sh("echo").stdin(sh.INHERIT)
 
 
 def test_pipeline_redirect_ellipsis_stdout():
     "Test use of Ellipsis in pipeline."
     cmd = sh("echo") | ...
-    assert cmd == sh("echo").stdout(shellous.INHERIT)
+    assert cmd == sh("echo").stdout(sh.INHERIT)
 
 
 def test_pipeline_redirect_tuple_stdin():
     "Test use of empty tuple in pipeline."
     cmd = () | sh("echo")
-    assert cmd == sh("echo").stdin(shellous.CAPTURE)
+    assert cmd == sh("echo").stdin(sh.CAPTURE)
 
 
 def test_pipeline_redirect_tuple_stdout():
     "Test use of empty tuple in pipeline."
     cmd = sh("echo") | ()
-    assert cmd == sh("echo").stdout(shellous.CAPTURE)
+    assert cmd == sh("echo").stdout(sh.CAPTURE)
 
 
 def test_pipeline_percent_op():

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -6,7 +6,7 @@ import re
 import sys
 
 import pytest
-from shellous import CAPTURE, sh
+from shellous import sh
 from shellous.harvest import harvest_results
 from shellous.log import LOGGER
 
@@ -58,7 +58,7 @@ async def run_asyncio_repl(cmds, logfile=None):
     errbuf = bytearray()
     repl = (
         sh(sys.executable, "-m", "asyncio")
-        .stdin(CAPTURE)
+        .stdin(sh.CAPTURE)
         .stderr(errbuf)
         .set(return_result=True, inherit_env=False)
         .env(**_current_env())
@@ -132,16 +132,16 @@ def test_parse_readme():
         'cmd = sh("echo", "def") >> output_file',
         "await cmd",
         "output_file.read_bytes()",
-        'cmd = sh("cat", "does_not_exist").stderr(shellous.STDOUT)',
+        'cmd = sh("cat", "does_not_exist").stderr(sh.STDOUT)',
         "await cmd.set(exit_codes={0,1})",
-        'cmd = sh("cat", "does_not_exist").stderr(shellous.INHERIT)',
+        'cmd = sh("cat", "does_not_exist").stderr(sh.INHERIT)',
         "await cmd",
         'pipe = sh("ls") | sh("grep", "README")',
         "await pipe",
         'cmd = sh("grep", "README", sh("ls"))',
         "await cmd",
         "buf = bytearray()",
-        'cmd = sh("ls") | sh("tee", sh("grep", "README").writable | buf) | shellous.DEVNULL',
+        'cmd = sh("ls") | sh("tee", sh("grep", "README").writable | buf) | sh.DEVNULL',
         "await cmd",
         "buf",
         "async with pipe as run:\n"

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -801,7 +801,8 @@ async def test_pty_echo_exit_code(echo_cmd):
 async def test_redirect_to_arbitrary_tuple():
     "Test redirection to an arbitrary tuple."
     with pytest.raises(TypeError, match="unsupported output type"):
-        await (sh("echo") | (1, 2))
+        with pytest.deprecated_call():
+            await (sh("echo") | (1, 2))
 
 
 async def test_command_context_manager_api():

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import asyncstdlib as asl
 import pytest
-from shellous import CAPTURE, DEVNULL, INHERIT, PipeResult, Result, ResultError, sh
+from shellous import PipeResult, Result, ResultError, sh
 from shellous.harvest import harvest_results
 
 # 4MB + 1: Much larger than necessary.
@@ -43,7 +43,7 @@ def python_script():
     depending on environment variables.
     """
     source_file = Path("tests/python_script.py")
-    return sh(sys.executable, "-u", source_file).stderr(INHERIT)
+    return sh(sys.executable, "-u", source_file).stderr(sh.INHERIT)
 
 
 @pytest.fixture
@@ -420,7 +420,7 @@ async def test_redirect_stdin_inherit(echo_cmd):
     "Test reading stdin from INHERIT."
 
     try:
-        result = await echo_cmd("abc").stdin(INHERIT)
+        result = await echo_cmd("abc").stdin(sh.INHERIT)
         assert result == "abc"
     except io.UnsupportedOperation:
         # Raises UnsupportedOperation under code coverage.
@@ -506,7 +506,7 @@ async def test_broken_pipe_in_async_with_failed_pipeline(cat_cmd, echo_cmd):
     data = b"c" * PIPE_MAX_SIZE
     echo = echo_cmd.env(SHELLOUS_EXIT_CODE=7)
 
-    cmd = (data | cat_cmd | echo("abc")).stdin(CAPTURE).stdout(DEVNULL)
+    cmd = (data | cat_cmd | echo("abc")).stdin(sh.CAPTURE).stdout(sh.DEVNULL)
     async with cmd.run() as run:
         run.stdin.write(data)
         try:
@@ -597,7 +597,7 @@ async def test_encoding_utf8_split(cat_cmd):
     "Test reconstitution of split utf-8 chars in output."
 
     buf = io.StringIO()
-    cmd = CAPTURE | cat_cmd | buf
+    cmd = sh.CAPTURE | cat_cmd | buf
 
     async with cmd.run() as run:
         # Not split.
@@ -655,7 +655,7 @@ async def test_redirect_stdin_capture_iter(cat_cmd):
         RuntimeError,
         match="multiple capture not supported in iterator",
     ):
-        async with cat_cmd.stdin(CAPTURE).run() as run:
+        async with cat_cmd.stdin(sh.CAPTURE).run() as run:
             async for _ in run:
                 pass
 
@@ -666,7 +666,7 @@ async def test_pipe_redirect_stdin_capture_iter(cat_cmd, tr_cmd):
     with pytest.raises(
         RuntimeError, match="multiple capture not supported in iterator"
     ):
-        async with cmd.stdin(CAPTURE).run() as run:
+        async with cmd.stdin(sh.CAPTURE).run() as run:
             async for _ in run:
                 pass
 

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -341,19 +341,20 @@ async def test_redirect_output_stdout():
 
 
 async def test_redirect_output_none():
-    "Test redirecting command output to None (same as DEVNULL)."
-    result = await sh("echo", "789").stdout(None)
-    assert result == ""
+    "Test redirecting command output to None (deprecated)."
+    with pytest.deprecated_call():
+        result = await sh("echo", "789").stdout(None)
+        assert result == ""
 
 
 async def test_redirect_output_capture():
-    "Test redirecting command output to None (same as DEVNULL)."
+    "Test redirecting command output to CAPTURE."
     result = await sh("echo", "789").stdout(sh.CAPTURE)
     assert result == "789\n"
 
 
 async def test_redirect_output_inherit(capfd):
-    "Test redirecting command output to None (same as DEVNULL)."
+    "Test redirecting command output to INHERIT."
     result = await sh("echo", "789").stdout(sh.INHERIT)
     assert result == ""
     assert _readouterr(capfd) == ("789\n", "")
@@ -1551,9 +1552,9 @@ $4 ~ /^[0-9]+/ { sub(/[0-9]+/, "N", $9); print $4, $5, $9 }
 async def test_open_file_descriptors():
     "Test what file descriptors are open in the subprocess."
 
-    cmd = sh("cat").stdin(())
-    lsof = sh("lsof", "-n", "-P", "-p").stderr(1)
-    awk = sh("awk", _AWK_SCRIPT).stderr(1)
+    cmd = sh("cat").stdin(sh.CAPTURE)
+    lsof = sh("lsof", "-n", "-P", "-p").stderr(sh.STDOUT)
+    awk = sh("awk", _AWK_SCRIPT).stderr(sh.STDOUT)
 
     async with cmd.set(close_fds=True) as run:
         result = await (lsof(run.pid) | awk)
@@ -1571,9 +1572,9 @@ async def test_open_file_descriptors():
 async def test_open_file_descriptors_unclosed_fds():
     "Test what file descriptors are open in the subprocess (close_fds=False)."
 
-    cmd = sh("cat").stdin(())
-    lsof = sh("lsof", "-n", "-P", "-p").stderr(1)
-    awk = sh("awk", _AWK_SCRIPT).stderr(1)
+    cmd = sh("cat").stdin(sh.CAPTURE)
+    lsof = sh("lsof", "-n", "-P", "-p").stderr(sh.STDOUT)
+    awk = sh("awk", _AWK_SCRIPT).stderr(sh.STDOUT)
 
     async with cmd.set(close_fds=False) as run:
         result = await (lsof(run.pid) | awk)
@@ -1591,9 +1592,9 @@ async def test_open_file_descriptors_unclosed_fds():
 async def test_open_file_descriptors_pty():
     "Test what file descriptors are open in the pty subprocess."
 
-    cmd = sh("cat").stdin(())
-    lsof = sh("lsof", "-n", "-P", "-p").stderr(1)
-    awk = sh("awk", _AWK_SCRIPT).stderr(1)
+    cmd = sh("cat").stdin(sh.CAPTURE)
+    lsof = sh("lsof", "-n", "-P", "-p").stderr(sh.STDOUT)
+    awk = sh("awk", _AWK_SCRIPT).stderr(sh.STDOUT)
 
     async with cmd.set(close_fds=True, pty=True) as run:
         result = await (lsof(run.pid) | awk)
@@ -1614,9 +1615,9 @@ async def test_open_file_descriptors_pty():
 async def test_open_file_descriptors_pty_unclosed_fds():
     "Test what file descriptors are open in the pty (close_fds=False)."
 
-    cmd = sh("cat").stdin(())
-    lsof = sh("lsof", "-n", "-P", "-p").stderr(1)
-    awk = sh("awk", _AWK_SCRIPT).stderr(1)
+    cmd = sh("cat").stdin(sh.CAPTURE)
+    lsof = sh("lsof", "-n", "-P", "-p").stderr(sh.STDOUT)
+    awk = sh("awk", _AWK_SCRIPT).stderr(sh.STDOUT)
 
     async with cmd.set(close_fds=False, pty=True) as run:
         result = await (lsof(run.pid) | awk)


### PR DESCRIPTION
- Refer to redirection constants using the context, i.e. `sh.DEVNULL` rather than `shellous.DEVNULL`. 
- Redirection literals (None, ..., 1, ()) are deprecated.