### PR TITLE
Remove deprecated behaviors

### DIFF
--- a/shellous/__init__.py
+++ b/shellous/__init__.py
@@ -28,13 +28,6 @@ result = await sh("echo", "hello")
 ```
 """
 
-# TODO: These aliases here are deprecated; use the sh.CONSTANT forms.
-STDOUT = sh.STDOUT
-DEVNULL = sh.DEVNULL
-CAPTURE = sh.CAPTURE
-INHERIT = sh.INHERIT
-
-
 __all__ = [
     "sh",
     "CmdContext",

--- a/shellous/__init__.py
+++ b/shellous/__init__.py
@@ -16,14 +16,6 @@ from .runner import AUDIT_EVENT_SUBPROCESS_SPAWN  # noqa: F401
 if sys.platform != "win32":
     from .watcher import DefaultChildWatcher  # noqa: F401
 
-# TODO: This function is deprecated; do not use.
-def context() -> CmdContext:
-    "Construct a new execution context."
-    import warnings
-
-    warnings.warn("context() is deprecated; use sh.", DeprecationWarning)
-    return CmdContext()
-
 
 sh = CmdContext()
 """`sh` is the default command context (`CmdContext`).

--- a/shellous/redirect.py
+++ b/shellous/redirect.py
@@ -4,7 +4,6 @@ import asyncio
 import enum
 import io
 import os
-import warnings
 from logging import Logger
 from typing import Any, Optional, Union
 
@@ -48,19 +47,12 @@ class Redirect(enum.IntEnum):
         "Return object with literal values replaced by Redirect constant."
 
         if isinstance(literal, (tuple, type(...), type(None))):
-            warnings.warn(
-                f"literal {literal!r} is no longer supported",
-                DeprecationWarning,
-            )
+            raise TypeError(f"literal {literal!r} is unsupported")
 
         # For stderr, the literal `1` indicates that stderr is redirected to
         # the same place as STDOUT.
         if is_stderr and isinstance(literal, int) and literal == 1:
-            warnings.warn(
-                f"stderr literal {literal!r} is no longer supported",
-                DeprecationWarning,
-            )
-            return Redirect.STDOUT
+            raise TypeError(f"stderr literal {literal!r} is unupported")
 
         try:
             return _LITERAL_REDIRECT.get(literal, literal)

--- a/shellous/redirect.py
+++ b/shellous/redirect.py
@@ -88,14 +88,9 @@ STDIN_TYPES = (
     int,
     Redirect,
     asyncio.StreamReader,
-    type(None),
-    type(...),
-    tuple,
 )
 
 STDOUT_TYPES = (
-    str,
-    bytes,
     os.PathLike,
     bytearray,
     io.IOBase,
@@ -103,12 +98,9 @@ STDOUT_TYPES = (
     Redirect,
     Logger,
     asyncio.StreamWriter,
-    type(None),
-    type(...),
-    tuple,
 )
 
-STDOUT_APPEND_TYPES = (str, bytes, os.PathLike)
+STDOUT_APPEND_TYPES = (os.PathLike,)
 
 
 async def _drain(stream: asyncio.StreamWriter):

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -4,7 +4,6 @@ import asyncio
 import io
 import os
 import sys
-import warnings
 from logging import Logger
 from typing import Any
 

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -245,13 +245,9 @@ class _RunOptions:
 
         stdout = asyncio.subprocess.PIPE
 
-        # TODO: str|bytes as output are deprecated.
         if isinstance(output, (str, bytes, os.PathLike)):
-            if isinstance(output, (str, bytes)):
-                warnings.warn(
-                    "Using str|bytes as output file is deprecated",
-                    DeprecationWarning,
-                )
+            if isinstance(output, (str, bytes)):  # TODO: remove this check...
+                raise TypeError("Using str|bytes as output file is unsupported")
             mode = "ab" if append else "wb"
             stdout = open(output, mode=mode)  # pylint: disable=consider-using-with
             self.open_fds.append(stdout)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -219,9 +219,14 @@ def test_arg_checks_append():
     "Test that redirections with `append=True` use the allowed types."
 
     echo = sh("echo")
-    echo.stdout("/tmp/tmp_test_file", append=True)
-    echo.stdout(b"/tmp/tmp_test_file", append=True)
+
     echo.stdout(Path("/tmp/tmp_test_file"), append=True)
+
+    with pytest.raises(TypeError, match="append"):
+        echo.stdout("/tmp/tmp_test_file", append=True)
+
+    with pytest.raises(TypeError, match="append"):
+        echo.stdout(b"/tmp/tmp_test_file", append=True)
 
     with pytest.raises(TypeError, match="append"):
         echo.stdout(7, append=True)  # 7 is file descriptor

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -253,37 +253,37 @@ def test_pipeline_len_getitem():
 def test_pipeline_redirect_none_stdin():
     "Test use of None in pipeline."
     with pytest.raises(TypeError, match="unsupported"):
-        _cmd = None | sh("echo")
+        _ = None | sh("echo")
 
 
 def test_pipeline_redirect_none_stdout():
     "Test use of None in pipeline."
     with pytest.raises(TypeError, match="unsupported"):
-        _cmd = sh("echo") | None
+        _ = sh("echo") | None
 
 
 def test_pipeline_redirect_ellipsis_stdin():
     "Test use of Ellipsis in pipeline."
     with pytest.raises(TypeError, match="unsupported"):
-        _cmd = ... | sh("echo")
+        _ = ... | sh("echo")
 
 
 def test_pipeline_redirect_ellipsis_stdout():
     "Test use of Ellipsis in pipeline."
     with pytest.raises(TypeError, match="unsupported"):
-        _cmd = sh("echo") | ...
+        _ = sh("echo") | ...
 
 
 def test_pipeline_redirect_tuple_stdin():
     "Test use of empty tuple in pipeline."
     with pytest.raises(TypeError, match="unsupported"):
-        _cmd = () | sh("echo")
+        _ = () | sh("echo")
 
 
 def test_pipeline_redirect_tuple_stdout():
     "Test use of empty tuple in pipeline."
     with pytest.raises(TypeError, match="unsupported"):
-        _cmd = sh("echo") | ()
+        _ = sh("echo") | ()
 
 
 def test_pipeline_percent_op():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -27,8 +27,13 @@ def test_pipeline_name():
 
 
 def test_pipeline_cmd_append():
-    pipe = Pipeline.create(sh("cmd1").stdin("a"), sh("cmd2").stdout("b", append=True))
-    assert pipe.commands == (sh("cmd1").stdin("a"), sh("cmd2").stdout("b", append=True))
+    pipe = Pipeline.create(
+        sh("cmd1").stdin("a"), sh("cmd2").stdout(Path("b"), append=True)
+    )
+    assert pipe.commands == (
+        sh("cmd1").stdin("a"),
+        sh("cmd2").stdout(Path("b"), append=True),
+    )
 
 
 def test_pipeline():
@@ -57,13 +62,18 @@ def test_pipeline_input():
 
 
 def test_pipeline_output():
-    pipe = Pipeline.create(sh("echo")) | "/tmp/somefile"
-    assert pipe.commands == (sh("echo").stdout("/tmp/somefile"),)
+    pipe = Pipeline.create(sh("echo")) | Path("/tmp/somefile")
+    assert pipe.commands == (sh("echo").stdout(Path("/tmp/somefile")),)
+
+
+def test_pipeline_output_str():
+    with pytest.raises(TypeError, match="unsupported"):
+        _ = Pipeline.create(sh("echo")) | "/tmp/somefile"
 
 
 def test_pipeline_output_append():
-    pipe = Pipeline.create(sh("echo")) >> "/tmp/somefile"
-    assert pipe.commands == (sh("echo").stdout("/tmp/somefile", append=True),)
+    pipe = Pipeline.create(sh("echo")) >> Path("/tmp/somefile")
+    assert pipe.commands == (sh("echo").stdout(Path("/tmp/somefile"), append=True),)
 
 
 def test_pipeline_full():
@@ -72,22 +82,22 @@ def test_pipeline_full():
         "/tmp/input"
         | Pipeline.create(sh("cmd1"))
         | sh("cmd2")
-        | Pipeline.create(sh("cmd3")) >> "/tmp/output"
+        | Pipeline.create(sh("cmd3")) >> Path("/tmp/output")
     )
     assert pipe.commands == (
         sh("cmd1").stdin("/tmp/input"),
         sh("cmd2"),
-        sh("cmd3").stdout("/tmp/output", append=True),
+        sh("cmd3").stdout(Path("/tmp/output"), append=True),
     )
 
 
 def test_pipeline_pieces():
     input_ = "/tmp/input" | Pipeline.create(sh("cmd1"))
-    output = Pipeline.create(sh("cmd2")) >> "/tmp/output"
+    output = Pipeline.create(sh("cmd2")) >> Path("/tmp/output")
     pipe = input_ | output
     assert pipe.commands == (
         sh("cmd1").stdin("/tmp/input"),
-        sh("cmd2").stdout("/tmp/output", append=True),
+        sh("cmd2").stdout(Path("/tmp/output"), append=True),
     )
 
 
@@ -102,18 +112,18 @@ def test_pipeline_or_eq():
 
 def test_pipeline_rshift_eq():
     pipe = Pipeline.create(sh("ls"))
-    pipe >>= "/tmp/output"
+    pipe >>= Path("/tmp/output")
     assert pipe == Pipeline.create(
-        sh("ls").stdout("/tmp/output", append=True),
+        sh("ls").stdout(Path("/tmp/output"), append=True),
     )
 
 
 def test_pipeline_stderr():
     pipe = Pipeline.create(sh("ls"), sh("grep"))
-    pipe = pipe.stderr("/tmp/output", append=True)
+    pipe = pipe.stderr(Path("/tmp/output"), append=True)
 
     assert pipe == Pipeline.create(
-        sh("ls"), sh("grep").stderr("/tmp/output", append=True)
+        sh("ls"), sh("grep").stderr(Path("/tmp/output"), append=True)
     )
 
 
@@ -127,13 +137,13 @@ def test_pipeline_full_commands():
         | sh("cmd1")
         | sh("cmd2")
         | sh("cmd3")
-        | sh("cmd4") >> "/tmp/output"
+        | sh("cmd4") >> Path("/tmp/output")
     )
     assert pipe == Pipeline.create(
         sh("cmd1").stdin("/tmp/input"),
         sh("cmd2"),
         sh("cmd3"),
-        sh("cmd4").stdout("/tmp/output", append=True),
+        sh("cmd4").stdout(Path("/tmp/output"), append=True),
     )
 
 
@@ -145,18 +155,18 @@ def test_pipeline_or_eq_commands():
 
 def test_pipeline_rshift_eq_commands():
     pipe = sh("ls") | sh("grep")
-    pipe >>= "/tmp/output"
+    pipe >>= Path("/tmp/output")
     assert pipe == Pipeline.create(
         sh("ls"),
-        sh("grep").stdout("/tmp/output", append=True),
+        sh("grep").stdout(Path("/tmp/output"), append=True),
     )
 
 
 def test_pipeline_or_eq_input_commands():
     pipe = "/tmp/input"
     pipe |= sh("grep")
-    pipe |= "/tmp/output"
-    assert pipe == sh("grep").stdin("/tmp/input").stdout("/tmp/output")
+    pipe |= Path("/tmp/output")
+    assert pipe == sh("grep").stdin("/tmp/input").stdout(Path("/tmp/output"))
 
 
 def test_pipeline_path_input():
@@ -202,9 +212,9 @@ def test_invalid_pipeline_override_stdin():
 
 def test_invalid_pipeline_operators():
     "Test >> in the middle of a pipeline."
-    pipe = sh("echo") >> "/tmp/tmp_file" | sh("cat")
+    pipe = sh("echo") >> Path("/tmp/tmp_file") | sh("cat")
     assert pipe == Pipeline.create(
-        sh("echo").stdout("/tmp/tmp_file", append=True), sh("cat")
+        sh("echo").stdout(Path("/tmp/tmp_file"), append=True), sh("cat")
     )
 
 
@@ -290,8 +300,8 @@ def test_pipeline_percent_op():
 def test_pipeline_percent_precedence():
     "Test operator precedence with % operator."
 
-    cmd = sh("nohup") % sh("echo") >> "/tmp/output"
-    assert cmd == sh("nohup", sh("echo").args).stdout("/tmp/output", append=True)
+    cmd = sh("nohup") % sh("echo") >> Path("/tmp/output")
+    assert cmd == sh("nohup", sh("echo").args).stdout(Path("/tmp/output"), append=True)
 
     cmd = "xyz" | sh("nohup") % sh("echo") | sh("cat")
     assert cmd == "xyz" | sh("nohup", sh("echo").args) | sh("cat")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -242,44 +242,38 @@ def test_pipeline_len_getitem():
 
 def test_pipeline_redirect_none_stdin():
     "Test use of None in pipeline."
-    with pytest.deprecated_call():
-        cmd = None | sh("echo")
-        assert cmd == sh("echo").stdin(sh.DEVNULL)
+    with pytest.raises(TypeError, match="unsupported"):
+        _cmd = None | sh("echo")
 
 
 def test_pipeline_redirect_none_stdout():
     "Test use of None in pipeline."
-    with pytest.deprecated_call():
-        cmd = sh("echo") | None
-        assert cmd == sh("echo").stdout(sh.DEVNULL)
+    with pytest.raises(TypeError, match="unsupported"):
+        _cmd = sh("echo") | None
 
 
 def test_pipeline_redirect_ellipsis_stdin():
     "Test use of Ellipsis in pipeline."
-    with pytest.deprecated_call():
-        cmd = ... | sh("echo")
-        assert cmd == sh("echo").stdin(sh.INHERIT)
+    with pytest.raises(TypeError, match="unsupported"):
+        _cmd = ... | sh("echo")
 
 
 def test_pipeline_redirect_ellipsis_stdout():
     "Test use of Ellipsis in pipeline."
-    with pytest.deprecated_call():
-        cmd = sh("echo") | ...
-        assert cmd == sh("echo").stdout(sh.INHERIT)
+    with pytest.raises(TypeError, match="unsupported"):
+        _cmd = sh("echo") | ...
 
 
 def test_pipeline_redirect_tuple_stdin():
     "Test use of empty tuple in pipeline."
-    with pytest.deprecated_call():
-        cmd = () | sh("echo")
-        assert cmd == sh("echo").stdin(sh.CAPTURE)
+    with pytest.raises(TypeError, match="unsupported"):
+        _cmd = () | sh("echo")
 
 
 def test_pipeline_redirect_tuple_stdout():
     "Test use of empty tuple in pipeline."
-    with pytest.deprecated_call():
-        cmd = sh("echo") | ()
-        assert cmd == sh("echo").stdout(sh.CAPTURE)
+    with pytest.raises(TypeError, match="unsupported"):
+        _cmd = sh("echo") | ()
 
 
 def test_pipeline_percent_op():

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -807,9 +807,8 @@ async def test_pty_echo_exit_code(echo_cmd):
 
 async def test_redirect_to_arbitrary_tuple():
     "Test redirection to an arbitrary tuple."
-    with pytest.raises(TypeError, match="unsupported output type"):
-        with pytest.deprecated_call():
-            await (sh("echo") | (1, 2))
+    with pytest.raises(TypeError, match="unsupported"):
+        await (sh("echo") | (1, 2))
 
 
 async def test_command_context_manager_api():

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -299,33 +299,16 @@ async def test_redirect_output_str(tmp_path):
     out = tmp_path / "test_redirect_output_str"
 
     # Erase and write to file.
-    with pytest.deprecated_call():
-        result = await sh("echo", "test", 4, 5, 6).stdout(str(out))
-    assert result == ""
-    assert out.read_bytes() == b"test 4 5 6\n"
-
-    # Append to the above file.
-    with pytest.deprecated_call():
-        result = await sh("echo", ".2.").stdout(str(out), append=True)
-    assert result == ""
-    assert out.read_bytes() == b"test 4 5 6\n.2.\n"
+    with pytest.raises(TypeError, match="output file"):
+        await sh("echo", "test", 4, 5, 6).stdout(str(out))
 
 
 async def test_redirect_output_bytes(tmp_path):
     "Test redirecting command output to a filename string."
     out = tmp_path / "test_redirect_output_str"
 
-    # Erase and write to file.
-    with pytest.deprecated_call():
-        result = await sh("echo", "test", 4, 5, 6).stdout(bytes(out))
-    assert result == ""
-    assert out.read_bytes() == b"test 4 5 6\n"
-
-    # Append to the above file.
-    with pytest.deprecated_call():
-        result = await sh("echo", ".2.").stdout(bytes(out), append=True)
-    assert result == ""
-    assert out.read_bytes() == b"test 4 5 6\n.2.\n"
+    with pytest.raises(TypeError, match="output file"):
+        await sh("echo", "test", 4, 5, 6).stdout(bytes(out))
 
 
 async def test_redirect_output_file(tmp_path):
@@ -360,10 +343,9 @@ async def test_redirect_output_stdout():
 
 
 async def test_redirect_output_none():
-    "Test redirecting command output to None (deprecated)."
-    with pytest.deprecated_call():
-        result = await sh("echo", "789").stdout(None)
-        assert result == ""
+    "Test redirecting command output to None."
+    with pytest.raises(TypeError, match="None"):
+        await sh("echo", "789").stdout(None)
 
 
 async def test_redirect_output_capture():


### PR DESCRIPTION
Redirecting stdout/stderr to a string/bytes file name is no longer supported. (Use pathlib.Path.)