### PR TITLE
API changes to CmdContext and Runner.result().

### DIFF
--- a/shellous/command.py
+++ b/shellous/command.py
@@ -91,8 +91,8 @@ class Options:  # pylint: disable=too-many-instance-attributes
     error_close: bool = False
     "True if error object should be closed after subprocess launch."
 
-    encoding: Optional[str] = "utf-8"
-    "Specifies encoding of input/ouput. None means binary."
+    encoding: str = "utf-8"
+    "Specifies encoding of input/ouput."
 
     return_result: bool = False
     "True if we should return `Result` object instead of the output text/bytes."
@@ -245,7 +245,7 @@ class CmdContext:
         self,
         *,
         inherit_env: Unset[bool] = _UNSET,
-        encoding: Unset[Optional[str]] = _UNSET,
+        encoding: Unset[str] = _UNSET,
         return_result: Unset[bool] = _UNSET,
         catch_cancelled_error: Unset[bool] = _UNSET,
         exit_codes: Unset[Optional[Container[int]]] = _UNSET,
@@ -269,10 +269,7 @@ class CmdContext:
         kwargs = locals()
         del kwargs["self"]
         if encoding is None:
-            warn(
-                "encoding=None is deprecated; use encoding='latin1' instead",
-                DeprecationWarning,
-            )
+            raise TypeError("encoding cannot be None")
         return CmdContext(self.options.set(kwargs))
 
     def __call__(self, *args: Any) -> "Command":
@@ -367,7 +364,7 @@ class Command:
         self,
         *,
         inherit_env: Unset[bool] = _UNSET,
-        encoding: Unset[Optional[str]] = _UNSET,
+        encoding: Unset[str] = _UNSET,
         return_result: Unset[bool] = _UNSET,
         catch_cancelled_error: Unset[bool] = _UNSET,
         exit_codes: Unset[Optional[Container[int]]] = _UNSET,
@@ -500,10 +497,7 @@ class Command:
         kwargs = locals()
         del kwargs["self"]
         if encoding is None:
-            warn(
-                "encoding=None is deprecated; use encoding='latin1' instead",
-                DeprecationWarning,
-            )
+            raise TypeError("encoding cannot be None")
         return Command(self.args, self.options.set(kwargs))
 
     def _replace_args(self, new_args: list[Union[str, bytes]]) -> Self:

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -24,7 +24,6 @@ from typing import (
     TypeVar,
     Union,
 )
-from warnings import warn
 
 from typing_extensions import Self
 
@@ -268,7 +267,7 @@ class CmdContext:
         """
         kwargs = locals()
         del kwargs["self"]
-        if encoding is None:
+        if encoding is None:  # pyright: ignore[reportUnnecessaryComparison]
             raise TypeError("encoding cannot be None")
         return CmdContext(self.options.set(kwargs))
 
@@ -496,7 +495,7 @@ class Command:
         """
         kwargs = locals()
         del kwargs["self"]
-        if encoding is None:
+        if encoding is None:  # pyright: ignore[reportUnnecessaryComparison]
             raise TypeError("encoding cannot be None")
         return Command(self.args, self.options.set(kwargs))
 

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -279,6 +279,11 @@ class CmdContext:
         "Construct a new command."
         return Command(coerce(args), self.options)
 
+    @property
+    def result(self) -> Self:
+        "Set `return_result` and `exit_codes`."
+        return self.set(return_result=True, exit_codes=range(-255, 256))
+
 
 @dataclass(frozen=True)
 class Command:

--- a/shellous/result.py
+++ b/shellous/result.py
@@ -40,8 +40,8 @@ class Result:
     cancelled: bool
     "Command was cancelled."
 
-    encoding: Optional[str]
-    "Output encoding. None indicates no encoding."
+    encoding: str
+    "Output encoding."
 
     extra: Any = None
     "Used for pipeline results (see `PipeResult`)."
@@ -49,15 +49,11 @@ class Result:
     @property
     def output(self) -> str:
         "Output of command as a string."
-        if self.encoding is None:
-            raise TypeError("use output_bytes instead; encoding is None")
         return decode(self.output_bytes, self.encoding)
 
     @property
     def error(self) -> str:
         "Error from command as a string (if it is not redirected)."
-        if self.encoding is None:
-            raise TypeError("use error_bytes instead; encoding is None")
         return decode(self.error_bytes, self.encoding)
 
     def __bool__(self) -> bool:
@@ -86,7 +82,7 @@ def make_result(
     result_list: Union[Result, list[Union[Exception, Result]]],
     cancelled: bool,
     timed_out: bool = False,
-):
+) -> Union[str, Result]:
     """Convert list of results into a single pipe result.
 
     `result` can be a list of Result, ResultError or another Exception.
@@ -131,9 +127,6 @@ def make_result(
 
     if command.options.return_result:
         return result
-
-    if result.encoding is None:
-        return result.output_bytes
 
     return result.output
 

--- a/shellous/result.py
+++ b/shellous/result.py
@@ -82,7 +82,7 @@ def make_result(
     result_list: Union[Result, list[Union[Exception, Result]]],
     cancelled: bool,
     timed_out: bool = False,
-) -> Union[str, Result]:
+) -> Result:
     """Convert list of results into a single pipe result.
 
     `result` can be a list of Result, ResultError or another Exception.
@@ -125,10 +125,7 @@ def make_result(
     if (cancelled and not timed_out) or result.exit_code not in exit_codes:
         raise ResultError(result)
 
-    if command.options.return_result:
-        return result
-
-    return result.output
+    return result
 
 
 def _find_key_result(result_list: list[Union[Result, Exception]]) -> Result:

--- a/shellous/result.py
+++ b/shellous/result.py
@@ -69,7 +69,7 @@ class PipeResult:
     cancelled: bool
 
     @staticmethod
-    def from_result(result: Union[Exception, Result]):
+    def from_result(result: Union[BaseException, Result]):
         "Construct a `PipeResult` from a `Result`."
         if isinstance(result, ResultError):
             result = result.result
@@ -78,7 +78,7 @@ class PipeResult:
 
 
 def convert_result_list(
-    result_list: list[Union[Exception, Result]],
+    result_list: list[Union[BaseException, Result]],
     cancelled: bool,
 ):
     "Convert list of results into a single pipe result."
@@ -126,7 +126,7 @@ def check_result(
     return result
 
 
-def _find_key_result(result_list: list[Union[Result, Exception]]) -> Result:
+def _find_key_result(result_list: list[Union[Result, BaseException]]) -> Result:
     "Scan a result list and return the 'key' result."
     acc = None
 
@@ -153,7 +153,7 @@ def _compare_result(acc: Optional[Result], item: Result) -> Result:
     return acc
 
 
-def _get_result(item: Union[Result, Exception]) -> Result:
+def _get_result(item: Union[Result, BaseException]) -> Result:
     if isinstance(item, ResultError):
         return item.result
     assert isinstance(item, Result)

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -364,43 +364,44 @@ class Runner:
     ```
     """
 
-    stdin = None
+    stdin: Optional[asyncio.StreamWriter] = None
     "Process standard input."
 
-    stdout = None
+    stdout: Optional[asyncio.StreamReader] = None
     "Process standard output."
 
-    stderr = None
+    stderr: Optional[asyncio.StreamReader] = None
     "Process standard error."
+
+    _proc: Optional[asyncio.subprocess.Process] = None
 
     def __init__(self, command):
         self._options = _RunOptions(command)
         self._cancelled = False
-        self._proc = None
         self._tasks = []
         self._timer = None  # asyncio.TimerHandle
         self._timed_out = False  # True if runner timeout expired
         self._last_signal = None
 
     @property
-    def name(self):
+    def name(self) -> str:
         "Return name of process being run."
         return self.command.name
 
     @property
-    def command(self):
+    def command(self) -> "shellous.Command":
         "Return the command being run."
         return self._options.command
 
     @property
-    def pid(self):
+    def pid(self) -> Optional[int]:
         "Return the command's process ID."
         if not self._proc:
             return None
         return self._proc.pid
 
     @property
-    def returncode(self):
+    def returncode(self) -> Optional[int]:
         "Process's exit code."
         if not self._proc:
             if self._cancelled:
@@ -415,7 +416,7 @@ class Runner:
         return code
 
     @property
-    def cancelled(self):
+    def cancelled(self) -> bool:
         "Return True if the command was cancelled."
         return self._cancelled
 

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -889,7 +889,10 @@ class Runner:
                 if stream:
                     await redir.copy_bytearray(stream, output_bytes)
 
-        return run.result(bytes(output_bytes))
+        result = run.result(bytes(output_bytes))
+        if command.options.return_result:
+            return result
+        return result.output
 
 
 class PipeRunner:
@@ -1101,7 +1104,11 @@ class PipeRunner:
         run = PipeRunner(pipe, capturing=False)
         async with run:
             pass
-        return run.result()
+
+        result = run.result()
+        if pipe.options.return_result:
+            return result
+        return result.output
 
 
 def _uses_process_substitution(cmd: "shellous.Command") -> bool:

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -76,7 +76,7 @@ class _RunOptions:
     """
 
     command: "shellous.Command"
-    encoding: Optional[str]
+    encoding: str
     open_fds: list[Union[int, SupportsClose]]
     input_bytes: Optional[bytes]
     pos_args: list[Union[str, bytes]]
@@ -111,7 +111,7 @@ class _RunOptions:
 
             # If executable does not include an absolute/relative directory,
             # resolve it using PATH.
-            if not os.path.dirname(self.pos_args[0]):
+            if not os.path.dirname(self.pos_args[0]):  # type: ignore (path)
                 self.pos_args[0] = which(self.pos_args[0])
 
         except Exception as ex:
@@ -923,6 +923,8 @@ class PipeRunner:
     stderr = None
     "Pipeline standard error."
 
+    _results: Optional[list[Union[BaseException, Result]]] = None
+
     def __init__(self, pipe, *, capturing):
         """`capturing=True` indicates we are within an `async with` block and
         client needs to access `stdin` and `stderr` streams.
@@ -932,7 +934,6 @@ class PipeRunner:
         self._pipe = pipe
         self._cancelled = False
         self._tasks = []
-        self._results = None
         self._capturing = capturing
         self._encoding = pipe.options.encoding
 

--- a/shellous/util.py
+++ b/shellous/util.py
@@ -34,6 +34,7 @@ def decode(data: Optional[bytes], encoding: str) -> str:
     "Utility function to decode optional byte strings."
     if not data:
         return ""
+    assert isinstance(encoding, str)
     return data.decode(*encoding.split(maxsplit=1))
 
 

--- a/shellous/util.py
+++ b/shellous/util.py
@@ -155,7 +155,7 @@ async def uninterrupted(coro: Coroutine[Any, Any, Any]):
         raise
 
 
-def which(command: str):
+def which(command: Union[str, bytes]):
     "Given a command without a directory, return the fully qualified path."
     path = shutil.which(command)
     if path is None:

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -360,3 +360,10 @@ def test_context_enums():
     assert sh.DEVNULL.name == "DEVNULL"
     assert sh.INHERIT.name == "INHERIT"
     assert sh.STDOUT.name == "STDOUT"
+
+
+def test_context_result():
+    "Test that `sh` supports the .result modifier."
+    ctxt = sh.result
+    assert ctxt.options.return_result
+    assert ctxt.options.exit_codes == range(-255, 256)

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -120,13 +120,10 @@ async def test_tr(tr_cmd):
 
 
 async def test_bulk(bulk_cmd):
-    with pytest.warns(DeprecationWarning):
-        result = await bulk_cmd().set(encoding=None)
-        assert len(result) == 4 * (1024 * 1024 + 1)
-        value = hashlib.sha256(result).hexdigest()
-        assert (
-            value == "462d6c497b393d2c9e1584a7b4636592da837ef66cf4ff871dc937f3fe309459"
-        )
+    result = await bulk_cmd().set(encoding="latin1")
+    assert len(result) == 4 * (1024 * 1024 + 1)
+    value = hashlib.sha256(result.encode("latin1")).hexdigest()
+    assert value == "462d6c497b393d2c9e1584a7b4636592da837ef66cf4ff871dc937f3fe309459"
 
 
 async def test_count(count_cmd):
@@ -473,9 +470,8 @@ async def test_redirect_stdin_stringio(cat_cmd):
 async def test_redirect_stdin_stringio_no_encoding(cat_cmd):
     "Test reading stdin from StringIO with encoding=None"
     buf = io.StringIO("123")
-    with pytest.warns(DeprecationWarning):
-        with pytest.raises(TypeError, match="input must be bytes"):
-            await cat_cmd().stdin(buf).set(encoding=None)
+    with pytest.raises(TypeError, match="encoding cannot be None"):
+        await cat_cmd().stdin(buf).set(encoding=None)
 
 
 async def test_redirect_stdin_inherit(echo_cmd):
@@ -815,27 +811,23 @@ async def test_process_substitution(echo_cmd, cat_cmd):
         assert result == "abc"
 
 
-async def test_async_iter_with_bytes_encoding(cat_cmd):
+async def test_async_iter_with_latin1_encoding(cat_cmd):
     "Test async iteration with encoding=None."
 
-    with pytest.warns(DeprecationWarning):
-        cmd = b"a\nb\nc\nd" | cat_cmd.set(encoding=None)
-
+    cmd = b"a\nb\nc\nd" | cat_cmd.set(encoding="latin1")
     async with cmd.run() as run:
         lines = [line async for line in run]
 
-    assert lines == [b"a\n", b"b\n", b"c\n", b"d"]
+    assert lines == ["a\n", "b\n", "c\n", "d"]
 
 
 async def test_stringio_redirect_with_bytes_encoding(echo_cmd):
     "Can't use StringIO redirect output buffer with encoding=None."
-
     buf = io.StringIO()
     cmd = echo_cmd | buf
 
-    with pytest.warns(DeprecationWarning):
-        with pytest.raises(TypeError, match="StringIO"):
-            await cmd("abc").set(encoding=None)
+    with pytest.raises(TypeError, match="encoding cannot be None"):
+        await cmd("abc").set(encoding=None)
 
 
 async def test_quick_cancel(echo_cmd):

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -157,7 +157,7 @@ async def test_error_bulk(error_cmd):
 async def test_error_result():
     result = await sh.result(sys.executable, "-c", "print('hello')")
     assert result.exit_code == 0
-    assert result.output == "hello\n"
+    assert result.output.rstrip() == "hello"
     assert result.error == ""
 
 

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -154,6 +154,13 @@ async def test_error_bulk(error_cmd):
     assert result.error == "1" * 1024
 
 
+async def test_error_result():
+    result = await sh.result(sys.executable, "-c", "print('hello')")
+    assert result.exit_code == 0
+    assert result.output == "hello\n"
+    assert result.error == ""
+
+
 async def test_nonexistant_cmd():
     with pytest.raises(FileNotFoundError):
         await sh("non_existant_command").set(return_result=True)
@@ -246,10 +253,15 @@ async def test_echo_result(echo_cmd):
     "Test the .result modifier with a single command."
     echo = echo_cmd.env(SHELLOUS_EXIT_CODE=17)
 
-    result = await echo("def").result
-    assert result.exit_code == 17
-    assert result.output == "def"
-    assert not result
+    result1 = await echo("def").result
+    assert result1.exit_code == 17
+    assert result1.output == "def"
+    assert not result1
+
+    result2 = await echo.result("xyz")  # preferred syntax
+    assert result2.exit_code == 17
+    assert result2.output == "xyz"
+    assert not result2
 
 
 async def test_pipe_result_1(echo_cmd, tr_cmd):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -34,7 +34,7 @@ def test_decode_encoding_none():
     # Invalid but allowed.
     assert decode(None, None) == ""
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(AssertionError):
         decode(b"abc", None)
 
 

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -683,7 +683,14 @@ async def test_multiple_capture():
         run.stdin.close()
 
     result = run.result(output)
-    assert result == "abc\n"
+    assert result == Result(
+        exit_code=0,
+        output_bytes=b"abc\n",
+        error_bytes=b"",
+        cancelled=False,
+        encoding="utf-8",
+        extra=None,
+    )
 
 
 async def test_multiple_capture_alpine():

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -74,9 +74,8 @@ async def test_echo():
 
 async def test_echo_bytes():
     "Test running the echo command with bytes output (deprecated)."
-    with pytest.warns(DeprecationWarning):
-        result = await sh("echo", "-n", "foo").set(encoding=None)
-        assert result == b"foo"
+    with pytest.raises(TypeError, match="encoding cannot be None"):
+        await sh("echo", "-n", "foo").set(encoding=None)
 
 
 async def test_echo_with_result():
@@ -267,21 +266,10 @@ async def test_input_bytes():
     assert result == "SOME INPUT"
 
 
-async def test_input_wrong_encoding():
-    "Test calling a command with input string, but bytes encoding expected."
-    with pytest.warns(DeprecationWarning):
-        xsh = sh.set(encoding=None)
-        tr = xsh("tr", "[:lower:]", "[:upper:]")
-        with pytest.raises(TypeError, match="input must be bytes"):
-            await tr.stdin("some input")
-
-
 async def test_input_none_encoding():
     "Test calling a command with input string, but bytes encoding expected."
-    with pytest.warns(DeprecationWarning):
-        tr = sh("tr", "[:lower:]", "[:upper:]").set(encoding=None)
-        result = await tr.stdin(b"here be bytes")
-        assert result == b"HERE BE BYTES"
+    with pytest.raises(TypeError, match="encoding cannot be None"):
+        sh("tr", "[:lower:]", "[:upper:]").set(encoding=None)
 
 
 async def test_exit_code_error():


### PR DESCRIPTION
- Add .result modifier to CmdContext. (so `sh.result('echo')` will return a Result object).
- `encoding` can no longer be None.
- `Runner.result()` will always return a Result object.
- `PipeRunner.result()` will always return a Result object.
- Various typing fixes.