### PR TITLE
Allow redirect with "append" for more types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,6 @@ Shellous supports different STDOUT behavior when using different Python types.
 | sh.CAPTURE | Capture output for `async with`. 🔹 | 
 | sh.DEVNULL | Write output to `/dev/null`. 🔹 | 
 | sh.INHERIT  | Write output to existing `sys.stdout` or `sys.stderr`. 🔹 | 
-| sh.STDOUT | Redirect stderr to same place as stdout. 🔹 | 
 
 🔹 For these types, there is no difference between using `|` and `>>`.
 
@@ -278,8 +277,9 @@ If you intend to redirect output to a file, you must use a `pathlib.Path` object
 By default, the first 1024 bytes of standard error is collected into the Result object.
 
 To redirect standard error, use the `stderr` method. Standard error supports the
-same Python types as standard output. To redirect stderr to the same place as stdout, 
-use the `sh.STDOUT` constant.
+same Python types as standard output. To append, set `append=True` in the `stderr` method.
+
+To redirect stderr to the same place as stdout, use the `sh.STDOUT` constant.
 
 ```pycon
 >>> cmd = sh("cat", "does_not_exist").stderr(sh.STDOUT)
@@ -306,15 +306,14 @@ If you redirect stderr, it will no longer be stored in the Result object.
 For regular commands, the default redirections are:
 
 - Standard input is read from the empty string ("").
-- Standard out is buffered by the program and returned (BUFFER).
-- Standard error is captured and stored in the Result object (BUFFER).
+- Standard out is buffered and stored in the Result object (BUFFER).
+- First 1024 bytes of standard error is buffered and stored in the Result object (BUFFER).
 
 However, the default redirections are adjusted when using a pseudo-terminal (pty):
 
 - Standard input is captured and ignored (CAPTURE).
-- Standard out is captured by the program and returned (BUFFER).
+- Standard out is buffered and stored in the Result object (BUFFER).
 - Standard error is redirected to standard output (STDOUT).
-
 
 ## Pipelines
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ with `|`.
 To redirect to or from a file, use a `pathlib.Path` object. Alternatively, you can redirect input/output
 to a StringIO object, an open file, a Logger, or use a special redirection constant like `sh.DEVNULL`.
 
+**IMPORTANT**: When combining the redirect operators with `await`, you must use parentheses. Remember that `await` has higher precedence than `|` and `>>`.
+
 ### Redirecting Standard Input
 
 To redirect standard input, use the pipe operator `|` with the argument on the **left-side**.

--- a/README.md
+++ b/README.md
@@ -255,20 +255,22 @@ b'abc\ndef\n'
 
 Shellous supports different STDOUT behavior when using different Python types.
 
-| Python Type | Behavior as STDOUT/STDERR | append=True
-| ----------- | --------------- | ------
-| Path | Write output to file path specified by `Path`. | Open file for append
-| bytearray | Write output to mutable byte array. | TypeError
-| File, StringIO, ByteIO | Write output to open file object. | TypeError
-| int | Write output to existing file descriptor. | TypeError
-| logging.Logger | Log each line of output. | TypeError
-| asyncio.StreamWriter | Write output to `StreamWriter`. | TypeError
-| sh.CAPTURE | Capture output for `async with`. | TypeError
-| sh.DEVNULL | Write output to `/dev/null`. | TypeError
-| sh.INHERIT  | Write output to existing `sys.stdout` or `sys.stderr`. | TypeError
-| sh.STDOUT | Redirect stderr to same place as stdout. | TypeError
+| Python Type | Behavior as STDOUT/STDERR | 
+| ----------- | --------------- | 
+| Path | Write output to the file path specified by `Path`.  | 
+| bytearray | Write output to a mutable byte array. | 
+| File, StringIO, ByteIO | Write output to an open file object. | 
+| int | Write output to existing file descriptor at its current position. 🔹 | 
+| logging.Logger | Log each line of output. 🔹 | 
+| asyncio.StreamWriter | Write output to `StreamWriter`. 🔹 | 
+| sh.CAPTURE | Capture output for `async with`. 🔹 | 
+| sh.DEVNULL | Write output to `/dev/null`. 🔹 | 
+| sh.INHERIT  | Write output to existing `sys.stdout` or `sys.stderr`. 🔹 | 
+| sh.STDOUT | Redirect stderr to same place as stdout. 🔹 | 
 
-Shellous does not support redirecting standard output/error to a plain `str` or `bytes` object. 
+🔹 For these types, there is no difference between using `|` and `>>`.
+
+Shellous does **not** support redirecting standard output/error to a plain `str` or `bytes` object. 
 If you intend to redirect output to a file, you must use a `pathlib.Path` object.
 
 ### Redirecting Standard Error
@@ -304,13 +306,13 @@ If you redirect stderr, it will no longer be stored in the Result object.
 For regular commands, the default redirections are:
 
 - Standard input is read from the empty string ("").
-- Standard out is captured by the program and returned (CAPTURE).
-- Standard error is captured and stored in the Result object (RESULT).
+- Standard out is buffered by the program and returned (BUFFER).
+- Standard error is captured and stored in the Result object (BUFFER).
 
 However, the default redirections are adjusted when using a pseudo-terminal (pty):
 
 - Standard input is captured and ignored (CAPTURE).
-- Standard out is captured by the program and returned (CAPTURE).
+- Standard out is captured by the program and returned (BUFFER).
 - Standard error is redirected to standard output (STDOUT).
 
 
@@ -322,6 +324,14 @@ You can create a pipeline by combining commands using the `|` operator.
 >>> pipe = sh("ls") | sh("grep", "README")
 >>> await pipe
 'README.md\n'
+```
+
+A pipeline returns a `Result` if the last command in the pipeline has the `.result` modifier.
+
+```pycon
+>>> pipe = sh("ls") | sh("grep", "README").result
+>>> await pipe
+Result(exit_code=0, output_bytes=b'README.md\n', error_bytes=b'', cancelled=False, encoding='utf-8', extra=(PipeResult(exit_code=0, cancelled=False), PipeResult(exit_code=0, cancelled=False)))
 ```
 
 ## Process Substitution (Unix Only)
@@ -347,6 +357,7 @@ bytearray(b'README.md\n')
 ```
 
 The above example is equivalent to `ls | tee >(grep README > buf) > /dev/null`.
+
 ## Timeouts
 
 You can specify a timeout using the `timeout` option. If the timeout expires, shellous will raise

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -32,8 +32,6 @@ from typing import (
 import shellous
 from shellous.pty_util import PtyAdapterOrBool
 from shellous.redirect import (
-    APPEND_TYPES,
-    APPEND_TYPES_T,
     STDIN_TYPES,
     STDIN_TYPES_T,
     STDOUT_TYPES,
@@ -379,7 +377,6 @@ class Command(Generic[_RT]):
         close: bool = False,
     ) -> "Command[_RT]":
         "Redirect standard output to `output`."
-        _check_args(output, append)
         new_options = self.options.set_stdout(output, append, close)
         return Command(self.args, new_options)
 
@@ -391,7 +388,6 @@ class Command(Generic[_RT]):
         close: bool = False,
     ) -> "Command[_RT]":
         "Redirect standard error to `error`."
-        _check_args(error, append)
         new_options = self.options.set_stderr(error, append, close)
         return Command(self.args, new_options)
 
@@ -647,10 +643,10 @@ class Command(Generic[_RT]):
             return self.stdin(lhs)
         return NotImplemented
 
-    def __rshift__(self, rhs: APPEND_TYPES_T) -> "Command[_RT]":
+    def __rshift__(self, rhs: STDOUT_TYPES_T) -> "Command[_RT]":
         "Right shift operator is used to build pipelines."
         if isinstance(
-            rhs, APPEND_TYPES
+            rhs, STDOUT_TYPES
         ):  # pyright: ignore[reportUnnecessaryIsInstance]
             return self.stdout(rhs, append=True)
         return NotImplemented
@@ -673,11 +669,6 @@ class Command(Generic[_RT]):
             Command[shellous.Result],
             self.set(_return_result=True, exit_codes=range(-255, 256)),
         )
-
-
-def _check_args(out: Any, append: bool):
-    if append and not isinstance(out, APPEND_TYPES):
-        raise TypeError(f"{type(out)} does not support append")
 
 
 def coerce(args: Sequence[Any]) -> tuple[Any, ...]:

--- a/shellous/pipeline.py
+++ b/shellous/pipeline.py
@@ -7,8 +7,6 @@ from typing import Any, Coroutine, Generic, Optional, TypeVar, Union, overload
 
 import shellous
 from shellous.redirect import (
-    APPEND_TYPES,
-    APPEND_TYPES_T,
     STDIN_TYPES,
     STDIN_TYPES_T,
     STDOUT_TYPES,
@@ -154,8 +152,8 @@ class Pipeline(Generic[_RT]):
             return self.stdin(lhs)
         return NotImplemented
 
-    def __rshift__(self, rhs: APPEND_TYPES_T) -> "Pipeline[_RT]":
-        if isinstance(rhs, APPEND_TYPES):
+    def __rshift__(self, rhs: STDOUT_TYPES_T) -> "Pipeline[_RT]":
+        if isinstance(rhs, STDOUT_TYPES):
             return self.stdout(rhs, append=True)
         if isinstance(rhs, (str, bytes)):
             raise TypeError(

--- a/shellous/redirect.py
+++ b/shellous/redirect.py
@@ -101,10 +101,6 @@ STDOUT_TYPES_T = Union[
     asyncio.StreamWriter,
 ]
 
-APPEND_TYPES = (Path,)
-
-APPEND_TYPES_T = Path
-
 
 async def _drain(stream: asyncio.StreamWriter):
     "Safe drain method."

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -1161,17 +1161,14 @@ def _signame(signal) -> str:
 
 
 def _set_position(output, append: bool):
-    "Truncate output stream object."
-    match output:
-        case bytearray():
-            if not append:
-                output.clear()
-        case io.IOBase():
-            if output.seekable():
-                if append:
-                    output.seek(0, io.SEEK_END)
-                else:
-                    output.truncate(0)
-                    output.seek(0, io.SEEK_SET)
-        case _:
-            pass
+    "Truncate/seek output stream object."
+    if isinstance(output, bytearray):
+        if not append:
+            output.clear()
+    elif isinstance(output, io.IOBase):
+        if output.seekable():
+            if append:
+                output.seek(0, io.SEEK_END)
+            else:
+                output.truncate(0)
+                output.seek(0, io.SEEK_SET)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -215,26 +215,6 @@ def test_options_hash_eq():
     assert opts2 != opts3
 
 
-def test_arg_checks_append():
-    "Test that redirections with `append=True` use the allowed types."
-
-    echo = sh("echo")
-
-    echo.stdout(Path("/tmp/tmp_test_file"), append=True)
-
-    with pytest.raises(TypeError, match="append"):
-        echo.stdout("/tmp/tmp_test_file", append=True)
-
-    with pytest.raises(TypeError, match="append"):
-        echo.stdout(b"/tmp/tmp_test_file", append=True)
-
-    with pytest.raises(TypeError, match="append"):
-        echo.stdout(7, append=True)  # 7 is file descriptor
-
-    with pytest.raises(TypeError, match="append"):
-        echo.stdout(sh.DEVNULL, append=True)
-
-
 def test_replace_args_method():
     "Test the Command set_args method."
     echo = sh("echo", 1, 2, 3)

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -145,6 +145,8 @@ def test_parse_readme():
         "await cmd",
         'pipe = sh("ls") | sh("grep", "README")',
         "await pipe",
+        'pipe = sh("ls") | sh("grep", "README").result',
+        "await pipe",
         'cmd = sh("grep", "README", sh("ls"))',
         "await cmd",
         "buf = bytearray()",

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,0 +1,139 @@
+"Test shellous output redirect behavior."
+
+from io import BytesIO, StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from shellous import sh
+
+# For Path, bytearray, and io.Base subclasses, writing to a sink should first
+# truncate the sink. Appending to a sink, should leave the original contents
+# in place.
+
+
+async def test_redirect_path():
+    "Test redirecting to an existing Path."
+    with TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir) / "testfile"
+        tmp.write_text("12345")
+
+        out = await (sh("echo", "abc") | tmp)
+        assert out == ""
+        assert tmp.read_text().rstrip() == "abc"
+
+
+async def test_redirect_path_append():
+    "Test redirecting to an existing Path with append."
+    with TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir) / "testfile"
+        tmp.write_text("12345")
+
+        out = await (sh("echo", "abc") >> tmp)
+        assert out == ""
+        assert tmp.read_text().rstrip() == "12345abc"
+
+
+async def test_redirect_bytearray():
+    "Test redirecting to an existing bytearray."
+    buf = bytearray(b"12345")
+    out = await (sh("echo", "abc") | buf)
+    assert out == ""
+    assert buf.rstrip() == b"abc"
+
+
+async def test_redirect_bytearray_append():
+    "Test redirecting to an existing bytearray with append."
+    buf = bytearray(b"12345")
+    out = await (sh("echo", "abc") >> buf)
+    assert out == ""
+    assert buf.rstrip() == b"12345abc"
+
+
+async def test_redirect_textfile():
+    "Test redirecting to an existing file."
+    with TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir) / "testfile"
+
+        with open(tmp, "w") as fp:
+            fp.write("12345")
+            out = await (sh("echo", "abc") | fp)
+
+        assert out == ""
+        assert tmp.read_text().rstrip() == "abc"
+
+
+async def test_redirect_textfile_append():
+    "Test redirecting to an existing file with append."
+    with TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir) / "testfile"
+
+        with open(tmp, "w") as fp:
+            fp.write("12345")
+            out = await (sh("echo", "abc") >> fp)
+
+        assert out == ""
+        assert tmp.read_text().rstrip() == "12345abc"
+
+
+async def test_redirect_binaryfile():
+    "Test redirecting to an existing file."
+    with TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir) / "testfile"
+
+        with open(tmp, "wb") as fp:
+            fp.write(b"12345")
+            out = await (sh("echo", "abc") | fp)
+
+        assert out == ""
+        assert tmp.read_text().rstrip() == "abc"
+
+
+async def test_redirect_binaryfile_append():
+    "Test redirecting to an existing file with append."
+    with TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir) / "testfile"
+
+        with open(tmp, "wb") as fp:
+            fp.write(b"12345")
+            out = await (sh("echo", "abc") >> fp)
+
+        assert out == ""
+        assert tmp.read_text().rstrip() == "12345abc"
+
+
+async def test_redirect_stringio():
+    "Test redirecting to an existing StringIO buffer."
+    buf = StringIO("12345")
+    out = await (sh("echo", "abc") | buf)
+    assert out == ""
+    assert buf.getvalue().rstrip() == "abc"
+
+
+async def test_redirect_stringio_append():
+    "Test redirecting to an existing StringIO buffer."
+    buf = StringIO("12345")
+    out = await (sh("echo", "abc") >> buf)
+    assert out == ""
+    assert buf.getvalue().rstrip() == "12345abc"
+
+
+async def test_redirect_bytesio():
+    "Test redirecting to an existing StringIO buffer."
+    buf = BytesIO(b"12345")
+    out = await (sh("echo", "abc") | buf)
+    assert out == ""
+    assert buf.getvalue().rstrip() == b"abc"
+
+
+async def test_redirect_bytesio_append():
+    "Test redirecting to an existing StringIO buffer."
+    buf = BytesIO(b"12345")
+    out = await (sh("echo", "abc") >> buf)
+    assert out == ""
+    assert buf.getvalue().rstrip() == b"12345abc"
+
+
+# For int, Redirect, Logger and StreamWriter, there is no difference between
+# writing and appending. The result is always an append.
+
+# TODO


### PR DESCRIPTION
- Fix bug in redirecting via `|` to a bytearray, StringIO or BytesIO where the original content was not replaced/truncated.
- Fix #359 