### PR TITLE
Minor clean up items.

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -19,7 +19,8 @@
         "pidfd",
         "kqueue",
         "nohup",
-        "preexec"
+        "preexec",
+        "SIGTERM"
     ],
     "ignorePaths": [
         "tests/**"

--- a/shellous/__init__.py
+++ b/shellous/__init__.py
@@ -14,12 +14,7 @@ from .command import AuditEventInfo, CmdContext, Command, Options
 from .pipeline import Pipeline
 from .pty_util import cbreak, cooked, raw
 from .result import Result, ResultError
-from .runner import (
-    AUDIT_EVENT_SUBPROCESS_SPAWN,
-    UNLAUNCHED_EXIT_CODE,
-    PipeRunner,
-    Runner,
-)
+from .runner import PipeRunner, Runner
 
 if sys.platform != "win32":
     from .watcher import DefaultChildWatcher
@@ -61,7 +56,5 @@ __all__ = [
     "Runner",
     "PipeRunner",
     "DefaultChildWatcher",
-    "AUDIT_EVENT_SUBPROCESS_SPAWN",
     "AuditEventInfo",
-    "UNLAUNCHED_EXIT_CODE",
 ]

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -166,7 +166,7 @@ class Options:  # pylint: disable=too-many-instance-attributes
     "Function called to audit stages of process execution."
 
     def merge_env(self) -> Optional[dict[str, str]]:
-        "Return our `env` merged with the global environment."
+        "@private Return our `env` merged with the global environment."
         if self.inherit_env:
             if not self.env:
                 return None
@@ -177,7 +177,7 @@ class Options:  # pylint: disable=too-many-instance-attributes
         return {}
 
     def set_stdin(self, input_: Any, close: bool) -> "Options":
-        "Return new options with `input` configured."
+        "@private Return new options with `input` configured."
         if input_ is None:
             raise TypeError("invalid stdin")
 
@@ -191,7 +191,7 @@ class Options:  # pylint: disable=too-many-instance-attributes
         )
 
     def set_stdout(self, output: Any, append: bool, close: bool) -> "Options":
-        "Return new options with `output` configured."
+        "@private Return new options with `output` configured."
         if output is None:
             raise TypeError("invalid stdout")
 
@@ -206,7 +206,7 @@ class Options:  # pylint: disable=too-many-instance-attributes
         )
 
     def set_stderr(self, error: Any, append: bool, close: bool) -> "Options":
-        "Return new options with `error` configured."
+        "@private Return new options with `error` configured."
         if error is None:
             raise TypeError("invalid stderr")
 
@@ -218,12 +218,12 @@ class Options:  # pylint: disable=too-many-instance-attributes
         )
 
     def set_env(self, updates: dict[str, Any]) -> "Options":
-        "Return new options with augmented environment."
+        "@private Return new options with augmented environment."
         new_env = EnvironmentDict(self.env, updates)
         return dataclasses.replace(self, env=new_env)
 
     def set(self, kwds: dict[str, Any]) -> "Options":
-        """Return new options with given properties updated.
+        """@private Return new options with given properties updated.
 
         See `Command.set` for option reference.
         """
@@ -232,14 +232,14 @@ class Options:  # pylint: disable=too-many-instance-attributes
 
     @overload
     def which(self, name: bytes) -> Optional[bytes]:
-        "Find the command with the given name and return its path."
+        "@private Find the command with the given name and return its path."
 
     @overload
     def which(self, name: str) -> Optional[str]:
-        "Find the command with the given name and return its path."
+        "@private Find the command with the given name and return its path."
 
     def which(self, name: Union[str, bytes]) -> Optional[Union[str, bytes]]:
-        "Find the command with the given name and return its path."
+        "@private Find the command with the given name and return its path."
         return shutil.which(name, path=self.path)
 
 

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -37,14 +37,13 @@ _KILL_TIMEOUT = 3.0
 _CLOSE_TIMEOUT = 0.25
 _UNKNOWN_EXIT_CODE = 255
 
-AUDIT_EVENT_SUBPROCESS_SPAWN = "byllyfish/shellous.subprocess_spawn"
+EVENT_SHELLOUS_EXEC = "shellous.exec"
 """Audit event raised by sys.audit() when shellous runs a subprocess.
-
 The audit event has one argument: the name of the command.
 """
 
-UNLAUNCHED_EXIT_CODE = -255
-"""Special exit code used in audit events when process launch itself
+CANCELLED_EXIT_CODE = -1000
+"""Special exit code used in audit callbacks when the process launch itself
 was cancelled."""
 
 
@@ -434,7 +433,7 @@ class Runner:
         if not self._proc:
             if self._cancelled:
                 # The process was cancelled before starting.
-                return UNLAUNCHED_EXIT_CODE
+                return CANCELLED_EXIT_CODE
             return None
         code = self._proc.returncode
         if code == _UNKNOWN_EXIT_CODE and self._last_signal is not None:
@@ -704,7 +703,7 @@ class Runner:
     async def _subprocess_exec(self, opts: _RunOptions):
         "Start the subprocess and assign to `self.proc`."
         with log_timer("asyncio.create_subprocess_exec"):
-            sys.audit(AUDIT_EVENT_SUBPROCESS_SPAWN, opts.pos_args[0])
+            sys.audit(EVENT_SHELLOUS_EXEC, opts.pos_args[0])
             with pty_util.set_ignore_child_watcher(
                 BSD_DERIVED and opts.pty_fds is not None
             ):

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -236,7 +236,7 @@ class _RunOptions:
             stdin=stdin,
             stdout=stdout,
             stderr=stderr,
-            env=options.merge_env(),
+            env=options.runtime_env(),
             start_new_session=start_session,
             preexec_fn=preexec_fn,
         )

--- a/shellous/util.py
+++ b/shellous/util.py
@@ -47,18 +47,8 @@ def encode_bytes(data: str, encoding: str) -> bytes:
 
 
 def coerce_env(env: dict[str, Any]) -> dict[str, str]:
-    """Utility function to coerce environment variables to string.
-
-    If the value of an environment variable is `...`, grab the value from the
-    parent environment.
-    """
-
-    def _coerce(key: str, value: Any):
-        if value is ...:
-            value = os.environ[key]
-        return str(value)
-
-    return {str(key): _coerce(key, value) for key, value in env.items()}
+    """Utility function to coerce environment variables to string."""
+    return {str(key): str(value) for key, value in env.items()}
 
 
 class SupportsClose(Protocol):

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -7,7 +7,8 @@ import sys
 
 import pytest
 
-from shellous import AUDIT_EVENT_SUBPROCESS_SPAWN, sh
+from shellous import sh
+from shellous.runner import EVENT_SHELLOUS_EXEC
 
 # pylint: disable=global-statement
 
@@ -59,9 +60,7 @@ async def test_audit():
         print(event.encode("ascii", "backslashreplace").decode("ascii"))
 
     # Check for my audit event.
-    assert any(
-        event.startswith(f"('{AUDIT_EVENT_SUBPROCESS_SPAWN}',") for event in events
-    )
+    assert any(event.startswith(f"('{EVENT_SHELLOUS_EXEC}',") for event in events)
 
     if not _is_uvloop():
         # uvloop doesn't implement audit hooks.
@@ -97,9 +96,7 @@ async def test_audit_posix_spawn():
         print(event.encode("ascii", "backslashreplace").decode("ascii"))
 
     # Check for my audit event.
-    assert any(
-        event.startswith(f"('{AUDIT_EVENT_SUBPROCESS_SPAWN}',") for event in events
-    )
+    assert any(event.startswith(f"('{EVENT_SHELLOUS_EXEC}',") for event in events)
 
     # Check for subprocess.Popen and os.posix_spawn.
     assert any(event.startswith("('subprocess.Popen',") for event in events)
@@ -130,7 +127,7 @@ async def test_audit_block_subprocess_spawn():
     global _HOOK
 
     def _hook(event, _args):
-        if event == AUDIT_EVENT_SUBPROCESS_SPAWN:
+        if event == EVENT_SHELLOUS_EXEC:
             raise RuntimeError("subprocess_spawn blocked")
 
     try:
@@ -155,7 +152,7 @@ async def test_audit_block_pipe_specific_cmd():
     grep_path = shutil.which("grep")
 
     def _hook(event, args):
-        if event == AUDIT_EVENT_SUBPROCESS_SPAWN and args[0] == grep_path:
+        if event == EVENT_SHELLOUS_EXEC and args[0] == grep_path:
             raise RuntimeError("grep blocked")
 
     callbacks = []

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -186,26 +186,30 @@ def test_command_env_init():
     cmd2 = ash("echo")
     assert cmd2.options.env == dict(A="1")
 
+    # The `env` method is additive.
     cmd3 = cmd2.env(B=2)
     assert cmd3.options.env == dict(A="1", B="2")
 
+    cmd4 = cmd3.env(A="3")
+    assert cmd4.options.env == dict(A="3", B="2")
 
-def test_options_merge_env():
-    "Test the internal Options class `merge_env` method."
+
+def test_options_runtime_env():
+    "Test the internal Options class `runtime_env` method."
     opts1 = Options()
     assert opts1.env is None
-    opts2 = opts1.set_env(dict(A=1))
+    opts2 = opts1.add_env(dict(A=1))
     opts3 = opts2.set(dict(inherit_env=False))
 
-    env1 = opts1.merge_env()
+    env1 = opts1.runtime_env()
     assert env1 is None
 
-    env2 = opts2.merge_env()
+    env2 = opts2.runtime_env()
     assert isinstance(env2, dict)
     assert "PATH" in env2
     assert env2["A"] == "1"
 
-    env3 = opts3.merge_env()
+    env3 = opts3.runtime_env()
     assert env3 == dict(A="1")
 
     sh2 = sh.env(B=2)
@@ -213,10 +217,40 @@ def test_options_merge_env():
     assert sh2.options.env == dict(B="2")
 
 
+def test_options_set_env():
+    "Test the Options class set(env=...) method."
+    opts = Options()
+    assert opts.env is None
+
+    opts = opts.set(dict(env={"A": "a"}))
+    assert opts.env == {"A": "a"}
+
+    opts = opts.set(dict(env={"B": 3}))
+    assert opts.env == {"B": "3"}
+
+    opts = opts.set(dict(env={}))
+    assert opts.env is None
+
+
+def test_command_set_env():
+    "Test the Command class set(env=...) method."
+    cmd1 = sh("echo")
+    assert cmd1.options.env is None
+
+    cmd1 = cmd1.set(env={"A": "a"})
+    assert cmd1.options.env == {"A": "a"}
+
+    cmd2 = cmd1.set(env={"B": 3})
+    assert cmd2.options.env == {"B": "3"}
+
+    cmd3 = cmd2.set(env={})
+    assert cmd3.options.env is None
+
+
 def test_options_hash_eq():
     "Test that the internal Options class is hashable."
     opts1 = Options()
-    opts2 = opts1.set_env(dict(A=1))
+    opts2 = opts1.add_env(dict(A=1))
     opts3 = opts2.set(dict(inherit_env=False))
 
     assert hash(opts1) is not None

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -13,16 +13,17 @@ from pathlib import Path
 import asyncstdlib as asl
 import pytest
 
-from shellous import UNLAUNCHED_EXIT_CODE, Result, ResultError, sh
+from shellous import Result, ResultError, sh
 from shellous.harvest import harvest_results
+from shellous.runner import CANCELLED_EXIT_CODE
 
 # 4MB + 1: Much larger than necessary.
 # See https://github.com/python/cpython/blob/main/Lib/test/support/__init__.py
 PIPE_MAX_SIZE = 4 * 1024 * 1024 + 1
 
 # On Windows, the exit_code of a terminated process is 1.
-CANCELLED_EXIT_CODE = -15 if sys.platform != "win32" else 1
-KILL_EXIT_CODE = -9 if sys.platform != "win32" else 1
+_ABORT_EXIT_CODE = -15 if sys.platform != "win32" else 1
+_KILL_EXIT_CODE = -9 if sys.platform != "win32" else 1
 
 
 def _is_uvloop():
@@ -256,7 +257,7 @@ async def test_echo_cancel_incomplete(echo_cmd):
 
     assert exc_info.type is ResultError
     assert exc_info.value.result == Result(
-        exit_code=CANCELLED_EXIT_CODE,
+        exit_code=_ABORT_EXIT_CODE,
         output_bytes=b"abc",
         error_bytes=b"",
         cancelled=True,
@@ -289,7 +290,7 @@ async def test_echo_cancel_stringio_incomplete(echo_cmd):
     assert buf.getvalue() == "abc"
     assert exc_info.type is ResultError
     assert exc_info.value.result == Result(
-        exit_code=CANCELLED_EXIT_CODE,
+        exit_code=_ABORT_EXIT_CODE,
         output_bytes=b"",
         error_bytes=b"",
         cancelled=True,
@@ -839,7 +840,7 @@ async def test_quick_cancel(echo_cmd):
         await task
 
     assert exc_info.value.result == Result(
-        exit_code=UNLAUNCHED_EXIT_CODE,
+        exit_code=CANCELLED_EXIT_CODE,
         output_bytes=b"",
         error_bytes=b"",
         cancelled=True,
@@ -1116,7 +1117,7 @@ async def test_audit_pipe_cancel(echo_cmd, tr_cmd):
         ("start", "tr", None, ""),
         ("stop", "echo", 0, ""),
         ("signal", "tr", None, "SIGTERM"),
-        ("stop", "tr", CANCELLED_EXIT_CODE, ""),
+        ("stop", "tr", _ABORT_EXIT_CODE, ""),
     ]
 
 
@@ -1175,7 +1176,7 @@ async def test_command_with_timeout_incomplete_result(sleep_cmd):
     result = await sleep(10).set(timeout=0.1)
 
     assert result == Result(
-        exit_code=CANCELLED_EXIT_CODE,
+        exit_code=_ABORT_EXIT_CODE,
         output_bytes=b"",
         error_bytes=b"",
         cancelled=True,
@@ -1191,7 +1192,7 @@ async def test_command_with_timeout_incomplete_resulterror(sleep_cmd):
         await sleep(10).set(timeout=0.1)
 
     assert exc_info.value.result == Result(
-        exit_code=CANCELLED_EXIT_CODE,
+        exit_code=_ABORT_EXIT_CODE,
         output_bytes=b"",
         error_bytes=b"",
         cancelled=True,
@@ -1226,7 +1227,7 @@ async def test_wait_for_zero_seconds(sleep_cmd):
         # Eager task started but was cancelled before launching process.
         assert calls == [
             ("start", "sleep", None, ""),
-            ("stop", "sleep", UNLAUNCHED_EXIT_CODE, "CancelledError"),
+            ("stop", "sleep", _ABORT_EXIT_CODE, "CancelledError"),
         ]
     else:
         # The task was cancelled before it even started, so there are no audit
@@ -1254,7 +1255,7 @@ async def test_timeout_zero_seconds(sleep_cmd):
     assert calls == [
         ("start", "sleep", None),
         ("signal", "sleep", None),
-        ("stop", "sleep", CANCELLED_EXIT_CODE),
+        ("stop", "sleep", _ABORT_EXIT_CODE),
     ]
 
 
@@ -1276,7 +1277,7 @@ async def test_timeout_negative_seconds(sleep_cmd):
     assert calls == [
         ("start", "sleep", None),
         ("signal", "sleep", None),
-        ("stop", "sleep", CANCELLED_EXIT_CODE),
+        ("stop", "sleep", _ABORT_EXIT_CODE),
     ]
 
 
@@ -1291,7 +1292,7 @@ async def test_command_timeout_incomplete_result(echo_cmd):
         await cmd
 
     assert exc_info.value.result == Result(
-        exit_code=CANCELLED_EXIT_CODE,
+        exit_code=_ABORT_EXIT_CODE,
         output_bytes=b"abc",
         error_bytes=b"",
         cancelled=True,
@@ -1313,7 +1314,7 @@ async def test_command_timeout_incomplete_result_exit_code(echo_cmd):
         await cmd
 
     assert exc_info.value.result == Result(
-        exit_code=CANCELLED_EXIT_CODE,
+        exit_code=_ABORT_EXIT_CODE,
         output_bytes=b"abc",
         error_bytes=b"",
         cancelled=True,
@@ -1322,7 +1323,7 @@ async def test_command_timeout_incomplete_result_exit_code(echo_cmd):
 
     # Test timeout, catch_cancelled_error, and exit_codes. You can't do this with
     # asyncio.wait_for; you have to use the timeout option.
-    cmd = cmd.set(exit_codes={CANCELLED_EXIT_CODE})
+    cmd = cmd.set(exit_codes={_ABORT_EXIT_CODE})
     result = await cmd
     assert result == "abc"
 

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -1227,7 +1227,7 @@ async def test_wait_for_zero_seconds(sleep_cmd):
         # Eager task started but was cancelled before launching process.
         assert calls == [
             ("start", "sleep", None, ""),
-            ("stop", "sleep", _ABORT_EXIT_CODE, "CancelledError"),
+            ("stop", "sleep", CANCELLED_EXIT_CODE, "CancelledError"),
         ]
     else:
         # The task was cancelled before it even started, so there are no audit

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -37,14 +37,6 @@ def test_coerce_env():
     result = coerce_env(dict(a="a", b=1))
     assert result == {"a": "a", "b": "1"}
 
-    # Test on Windows using SystemRoot env, otherwise test with PATH.
-    if "SystemRoot" in os.environ:
-        result = coerce_env(dict(SystemRoot=...))
-        assert result == {"SystemRoot": os.environ["SystemRoot"]}
-    else:
-        result = coerce_env(dict(PATH=...))
-        assert result == {"PATH": os.environ["PATH"]}
-
 
 def test_close_fds(tmp_path):
     "Test the close_fds() function."

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -766,20 +766,6 @@ async def test_large_cat():
     assert result.output_bytes == data
 
 
-async def test_env_ellipsis_unix():
-    "Test using `...` in env method to grab value from global environment."
-    cmd = sh("env").set(inherit_env=False).env(PATH=...)
-    result = await cmd
-    assert result.startswith("PATH=")
-
-
-async def test_env_ellipsis_unix_wrong_case():
-    "Test using `...` in env method to grab value from global environment."
-    # Fails because actual env is named "PATH", not "path"
-    with pytest.raises(KeyError):
-        sh("env").set(inherit_env=False).env(path=...)
-
-
 async def test_process_substitution():
     """Test process substitution.
 

--- a/tests/win32/test_win32.py
+++ b/tests/win32/test_win32.py
@@ -1,5 +1,6 @@
 "Unit tests for shellous module (Windows)."
 
+import os
 import sys
 from pathlib import Path
 
@@ -60,7 +61,7 @@ async def test_empty_env_echo(echo):
 async def test_empty_env_system_root():
     "Test running a command with just SYSTEM_ROOT env var."
     cmd = sh(sys.executable, "-c", "print('test1')")
-    result = await cmd.set(inherit_env=False).env(SystemRoot=...)
+    result = await cmd.set(inherit_env=False).env(SystemRoot=os.environ["SystemRoot"])
     assert result == "test1\r\n"
 
 


### PR DESCRIPTION
- Remove AUDIT_EVENT_SUBPROCESS_SPAWN and UNLAUNCHED_EXIT_CODE constants from public API. Renamed these constants internally.
- Option's methods are now private, undocumented.
- Added the cmd.set(env=...) option for setting the environment dictionary all at once, instead of using cmd.env() helper.
- `...` no longer gets special treatment when setting environment variables.
