### PR TITLE
Contextvar fixes and additional pytest testing

### DIFF
--- a/shellous/command.py
+++ b/shellous/command.py
@@ -660,7 +660,7 @@ class Command(Generic[_RT]):
 
     async def __aenter__(self) -> Runner:
         "Enter the async context manager."
-        return await context_aenter(id(self), Runner(self))
+        return await context_aenter(self, Runner(self))
 
     async def __aexit__(
         self,
@@ -669,7 +669,7 @@ class Command(Generic[_RT]):
         exc_tb: Optional[TracebackType],
     ) -> Optional[bool]:
         "Exit the async context manager."
-        return await context_aexit(id(self), exc_type, exc_value, exc_tb)
+        return await context_aexit(self, exc_type, exc_value, exc_tb)
 
     def __aiter__(self) -> AsyncIterator[str]:
         "Return async iterator to iterate over output lines."

--- a/shellous/pipeline.py
+++ b/shellous/pipeline.py
@@ -178,7 +178,7 @@ class Pipeline(Generic[_RT]):
 
     async def __aenter__(self) -> PipeRunner:
         "Enter the async context manager."
-        return await context_aenter(id(self), PipeRunner(self, capturing=True))
+        return await context_aenter(self, PipeRunner(self, capturing=True))
 
     async def __aexit__(
         self,
@@ -187,7 +187,7 @@ class Pipeline(Generic[_RT]):
         exc_tb: Optional[TracebackType],
     ) -> Optional[bool]:
         "Exit the async context manager."
-        return await context_aexit(id(self), exc_type, exc_value, exc_tb)
+        return await context_aexit(self, exc_type, exc_value, exc_tb)
 
     def __aiter__(self) -> AsyncIterator[str]:
         "Return async iterator to iterate over output lines."

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -387,8 +387,8 @@ class Runner:
     """Runner is an asynchronous context manager that runs a command.
 
     ```
-    async with cmd.run() as run:
-        # process run.stdin, run.stdout, run.stderr (if not None)
+    async with Runner(cmd) as run:
+        # process streams: run.stdin, run.stdout, run.stderr (if not None)
     result = run.result()
     ```
     """

--- a/shellous/util.py
+++ b/shellous/util.py
@@ -173,7 +173,8 @@ async def context_aexit(
 ) -> Optional[bool]:
     "Exit an async context manager."
     ctxt_stack = _CTXT_STACK.get()
-    assert ctxt_stack is not None  # (pyright)
+    if ctxt_stack is None:
+        raise RuntimeError("contextvar `ctxt_stack` is missing")
 
     stack = ctxt_stack[scope]
     ctxt_manager = stack.pop()

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,0 +1,54 @@
+"Unit tests for using shellous commands in a pytest fixture."
+
+import contextlib
+import contextvars
+
+import pytest
+
+from shellous import Runner, sh
+
+
+@pytest.fixture
+async def echo_broken():
+    "This fixture fails because pytest doesn't preserve context vars."
+    async with sh("echo") as run:
+        yield run
+
+
+@pytest.mark.xfail(raises=RuntimeError)
+async def test_echo_broken(echo_broken):
+    assert echo_broken.command.args[0] == "echo"
+
+
+@pytest.fixture
+async def echo_workaround():
+    "One work-around is to avoid the contextvar by calling Runner explicitly."
+    async with Runner(sh("echo")) as run:
+        yield run
+
+
+async def test_echo_workaround(echo_workaround):
+    assert echo_workaround.command.args[0] == "echo"
+
+
+@contextlib.contextmanager
+def _preserve_contextvars():
+    "Context manager that copies the `ctxt_stack` context var."
+    old_context = contextvars.copy_context()
+    yield
+    new_context = contextvars.copy_context()
+    for var in old_context:
+        if var.name.startswith("ctxt_") and var not in new_context:
+            var.set(old_context[var])
+
+
+@pytest.fixture
+async def echo_preserved():
+    "Another work-around explicitly copies the contextvars."
+    async with sh("echo") as run:
+        with _preserve_contextvars():
+            yield run
+
+
+async def test_echo_preserved(echo_preserved):
+    assert echo_preserved.command.args[0] == "echo"

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,8 +1,5 @@
 "Unit tests for using shellous commands in a pytest fixture."
 
-import contextlib
-import contextvars
-
 import pytest
 
 from shellous import Runner, sh
@@ -11,6 +8,7 @@ from shellous import Runner, sh
 @pytest.fixture
 async def echo_broken():
     """This fixture fails because pytest-asyncio doesn't preserve context vars.
+    It also executes the context __aenter__ and __aexit__ in different tasks.
 
     https://github.com/pytest-dev/pytest-asyncio/issues/127
     """

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -32,26 +32,3 @@ async def echo_workaround():
 
 async def test_echo_workaround(echo_workaround):
     assert echo_workaround.command.args[0] == "echo"
-
-
-@contextlib.contextmanager
-def _preserve_contextvars():
-    "Context manager that copies the `context_stack` context var."
-    old_context = contextvars.copy_context()
-    yield
-    new_context = contextvars.copy_context()
-    for var in old_context:
-        if var.name.startswith("shellous.") and var not in new_context:
-            var.set(old_context[var])
-
-
-@pytest.fixture
-async def echo_preserved():
-    "Another work-around explicitly copies the contextvars (a bit hacky)."
-    async with sh("echo") as run:
-        with _preserve_contextvars():
-            yield run
-
-
-async def test_echo_preserved(echo_preserved):
-    assert echo_preserved.command.args[0] == "echo"

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -10,7 +10,10 @@ from shellous import Runner, sh
 
 @pytest.fixture
 async def echo_broken():
-    "This fixture fails because pytest doesn't preserve context vars."
+    """This fixture fails because pytest-asyncio doesn't preserve context vars.
+
+    https://github.com/pytest-dev/pytest-asyncio/issues/127
+    """
     async with sh("echo") as run:
         yield run
 
@@ -33,18 +36,18 @@ async def test_echo_workaround(echo_workaround):
 
 @contextlib.contextmanager
 def _preserve_contextvars():
-    "Context manager that copies the `ctxt_stack` context var."
+    "Context manager that copies the `context_stack` context var."
     old_context = contextvars.copy_context()
     yield
     new_context = contextvars.copy_context()
     for var in old_context:
-        if var.name.startswith("ctxt_") and var not in new_context:
+        if var.name.startswith("shellous.") and var not in new_context:
             var.set(old_context[var])
 
 
 @pytest.fixture
 async def echo_preserved():
-    "Another work-around explicitly copies the contextvars."
+    "Another work-around explicitly copies the contextvars (a bit hacky)."
     async with sh("echo") as run:
         with _preserve_contextvars():
             yield run


### PR DESCRIPTION
- Test using shellous in a pytest fixture.
- Fix issue with context_aenter/context_aexit related to parent/child tasks.
- The contextvar is now called "shellous.context_stacks".