### PR TITLE
Prompt API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ You can retrieve an option from `cmd` with `cmd.options.<option>`. For example, 
 | path | Search path to use instead of the `PATH` environment variable. |
 | env | Additional environment variables to pass to the command. |
 | inherit_env | True if command should inherit the environment variables from the current process. (Default=True) |
-| encoding | Text encoding of input/output streams. (Default=UTF-8) |
+| encoding | Text encoding of input/output streams. You can specify an error handling scheme by including it after a space, e.g. "ascii backslashreplace". (Default="utf-8 strict") |
 | exit_codes | Set of exit codes that do not raise a `ResultError`. (DEFAULT={0}) |
 | timeout | Timeout in seconds to wait before cancelling the process. |
 | cancel_timeout | Timeout in seconds to wait for a cancelled process to exit before forcefully terminating it. (Default=3s) |

--- a/ci/requirements-dev.txt
+++ b/ci/requirements-dev.txt
@@ -1,4 +1,4 @@
-# Poetry (version 1.6.1) export at Sat Oct  7 21:49:06 MST 2023
+# Poetry (version 1.6.1) export at Tue Oct 10 13:05:24 MST 2023
 astroid==3.0.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:1defdbca052635dd29657ea674edfc45e4b5be9cd53630c5b084fcfed94344a8 \
     --hash=sha256:f2510e7fdcd6cfda4ec50014726d4857abf79acfc010084ce8c26091913f1b25
@@ -198,9 +198,9 @@ pytest-dotenv==0.5.2 ; python_version >= "3.9" and python_version < "4.0" \
 pytest-randomly==3.15.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0516f4344b29f4e9cdae8bce31c4aeebf59d0b9ef05927c33354ff3859eeeca6 \
     --hash=sha256:b908529648667ba5e54723088edd6f82252f540cc340d748d1fa985539687047
-pytest-timeout==2.1.0 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9 \
-    --hash=sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6
+pytest-timeout==2.2.0 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:3b0b95dabf3cb50bac9ef5ca912fa0cfc286526af17afc806824df20c2f72c90 \
+    --hash=sha256:bde531e096466f49398a59f2dde76fa78429a09a12411466f88a07213e220de2
 pytest==7.4.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002 \
     --hash=sha256:a766259cfab564a2ad52cb1aae1b881a75c3eb7e34ca3779697c23ed47c47069

--- a/ci/requirements-dev.txt
+++ b/ci/requirements-dev.txt
@@ -1,4 +1,4 @@
-# Poetry (version 1.6.1) export at Tue Oct 10 13:05:24 MST 2023
+# Poetry (version 1.6.1) export at Thu Oct 12 12:28:22 MST 2023
 astroid==3.0.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:1defdbca052635dd29657ea674edfc45e4b5be9cd53630c5b084fcfed94344a8 \
     --hash=sha256:f2510e7fdcd6cfda4ec50014726d4857abf79acfc010084ce8c26091913f1b25
@@ -186,9 +186,9 @@ pygments==2.16.1 ; python_version >= "3.9" and python_version < "4.0" \
 pylint==3.0.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:81c6125637be216b4652ae50cc42b9f8208dfb725cdc7e04c48f6902f4dbdf40 \
     --hash=sha256:9c90b89e2af7809a1697f6f5f93f1d0e518ac566e2ac4d2af881a69c13ad01ea
-pyright==1.1.330.post0 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:2e9e0878298685b66485b340a0aaa16342129eb03ff9ed0e3c1ab66b8bfbe914 \
-    --hash=sha256:8e5b09cc5d1cfa0bcbf8824b0316d21c43fe229da7cef0a09cd12fcf6cb3eedd
+pyright==1.1.331 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:c3e7b86154cac86c3bd61ea0f963143d001c201e246825aaabdddfcce5d04293 \
+    --hash=sha256:d200a01794e7f2a04d5042a6c3abee36ce92780287d3037edfc3604d45488f0e
 pytest-asyncio==0.21.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d \
     --hash=sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b

--- a/ci/requirements-dev.txt
+++ b/ci/requirements-dev.txt
@@ -1,10 +1,10 @@
-# Poetry (version 1.6.1) export at Wed Oct  4 21:55:52 MST 2023
+# Poetry (version 1.6.1) export at Sat Oct  7 21:49:06 MST 2023
 astroid==3.0.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:1defdbca052635dd29657ea674edfc45e4b5be9cd53630c5b084fcfed94344a8 \
     --hash=sha256:f2510e7fdcd6cfda4ec50014726d4857abf79acfc010084ce8c26091913f1b25
-asyncstdlib==3.10.8 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:e18b67de483dfbfec3c17ec2121a8a3fa9b950874ff03802819bd3b1af56148f \
-    --hash=sha256:eb0dbc697a238fe1ef141e29b3396ead816aaf8a28f07e584e05d1d9fb26841a
+asyncstdlib==3.10.9 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:2325840babe05a717ea6f03ae71a5bb7e93786e0d1df1d60aeb8069aac6746cc \
+    --hash=sha256:c5de1bf1c60de1203a9b135058dcfea7de2507d321e56279baca0905cd8628cd
 black==23.9.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:031e8c69f3d3b09e1aa471a926a1eeb0b9071f80b17689a655f7885ac9325a6f \
     --hash=sha256:13a2e4a93bb8ca74a749b6974925c27219bb3df4d42fc45e948a5d9feb5122b7 \
@@ -183,12 +183,12 @@ pluggy==1.3.0 ; python_version >= "3.9" and python_version < "4.0" \
 pygments==2.16.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692 \
     --hash=sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29
-pylint==3.0.0 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:21da8ed1294f88d66c82eb3e624a0993291613548bb17fbccaa220c31c41293b \
-    --hash=sha256:d22816c963816d7810b87afe0bdf5c80009e1078ecbb9c8f2e2a24d4430039b1
-pyright==1.1.329 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:5baf82ff5ecb8c8b3ac400e8536348efbde0b94a09d83d5b440c0d143fd151a8 \
-    --hash=sha256:c16f88a7ac14ddd0513e62fec56d69c37e3c6b412161ad16aa23a9c7e3dabaf4
+pylint==3.0.1 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:81c6125637be216b4652ae50cc42b9f8208dfb725cdc7e04c48f6902f4dbdf40 \
+    --hash=sha256:9c90b89e2af7809a1697f6f5f93f1d0e518ac566e2ac4d2af881a69c13ad01ea
+pyright==1.1.330.post0 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:2e9e0878298685b66485b340a0aaa16342129eb03ff9ed0e3c1ab66b8bfbe914 \
+    --hash=sha256:8e5b09cc5d1cfa0bcbf8824b0316d21c43fe229da7cef0a09cd12fcf6cb3eedd
 pytest-asyncio==0.21.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d \
     --hash=sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b

--- a/ci/requirements-uvloop.txt
+++ b/ci/requirements-uvloop.txt
@@ -1,4 +1,4 @@
-# Poetry (version 1.6.1) export at Tue Oct 10 13:05:24 MST 2023
+# Poetry (version 1.6.1) export at Thu Oct 12 12:28:22 MST 2023
 uvloop==0.17.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0949caf774b9fcefc7c5756bacbbbd3fc4c05a6b7eebc7c7ad6f825b23998d6d \
     --hash=sha256:0ddf6baf9cf11a1a22c71487f39f15b2cf78eb5bde7e5b45fbb99e8a9d91b9e1 \

--- a/ci/requirements-uvloop.txt
+++ b/ci/requirements-uvloop.txt
@@ -1,4 +1,4 @@
-# Poetry (version 1.6.1) export at Wed Oct  4 21:55:52 MST 2023
+# Poetry (version 1.6.1) export at Sat Oct  7 21:49:06 MST 2023
 uvloop==0.17.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0949caf774b9fcefc7c5756bacbbbd3fc4c05a6b7eebc7c7ad6f825b23998d6d \
     --hash=sha256:0ddf6baf9cf11a1a22c71487f39f15b2cf78eb5bde7e5b45fbb99e8a9d91b9e1 \

--- a/ci/requirements-uvloop.txt
+++ b/ci/requirements-uvloop.txt
@@ -1,4 +1,4 @@
-# Poetry (version 1.6.1) export at Sat Oct  7 21:49:06 MST 2023
+# Poetry (version 1.6.1) export at Tue Oct 10 13:05:24 MST 2023
 uvloop==0.17.0 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:0949caf774b9fcefc7c5756bacbbbd3fc4c05a6b7eebc7c7ad6f825b23998d6d \
     --hash=sha256:0ddf6baf9cf11a1a22c71487f39f15b2cf78eb5bde7e5b45fbb99e8a9d91b9e1 \

--- a/poetry.lock
+++ b/poetry.lock
@@ -468,13 +468,13 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pyright"
-version = "1.1.330.post0"
+version = "1.1.331"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.330.post0-py3-none-any.whl", hash = "sha256:2e9e0878298685b66485b340a0aaa16342129eb03ff9ed0e3c1ab66b8bfbe914"},
-    {file = "pyright-1.1.330.post0.tar.gz", hash = "sha256:8e5b09cc5d1cfa0bcbf8824b0316d21c43fe229da7cef0a09cd12fcf6cb3eedd"},
+    {file = "pyright-1.1.331-py3-none-any.whl", hash = "sha256:d200a01794e7f2a04d5042a6c3abee36ce92780287d3037edfc3604d45488f0e"},
+    {file = "pyright-1.1.331.tar.gz", hash = "sha256:c3e7b86154cac86c3bd61ea0f963143d001c201e246825aaabdddfcce5d04293"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -16,13 +16,13 @@ typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "asyncstdlib"
-version = "3.10.8"
+version = "3.10.9"
 description = "The missing async toolbox"
 optional = false
 python-versions = "~=3.6"
 files = [
-    {file = "asyncstdlib-3.10.8-py3-none-any.whl", hash = "sha256:eb0dbc697a238fe1ef141e29b3396ead816aaf8a28f07e584e05d1d9fb26841a"},
-    {file = "asyncstdlib-3.10.8.tar.gz", hash = "sha256:e18b67de483dfbfec3c17ec2121a8a3fa9b950874ff03802819bd3b1af56148f"},
+    {file = "asyncstdlib-3.10.9-py3-none-any.whl", hash = "sha256:2325840babe05a717ea6f03ae71a5bb7e93786e0d1df1d60aeb8069aac6746cc"},
+    {file = "asyncstdlib-3.10.9.tar.gz", hash = "sha256:c5de1bf1c60de1203a9b135058dcfea7de2507d321e56279baca0905cd8628cd"},
 ]
 
 [package.extras]
@@ -438,13 +438,13 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pylint"
-version = "3.0.0"
+version = "3.0.1"
 description = "python code static checker"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "pylint-3.0.0-py3-none-any.whl", hash = "sha256:21da8ed1294f88d66c82eb3e624a0993291613548bb17fbccaa220c31c41293b"},
-    {file = "pylint-3.0.0.tar.gz", hash = "sha256:d22816c963816d7810b87afe0bdf5c80009e1078ecbb9c8f2e2a24d4430039b1"},
+    {file = "pylint-3.0.1-py3-none-any.whl", hash = "sha256:9c90b89e2af7809a1697f6f5f93f1d0e518ac566e2ac4d2af881a69c13ad01ea"},
+    {file = "pylint-3.0.1.tar.gz", hash = "sha256:81c6125637be216b4652ae50cc42b9f8208dfb725cdc7e04c48f6902f4dbdf40"},
 ]
 
 [package.dependencies]
@@ -468,13 +468,13 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pyright"
-version = "1.1.329"
+version = "1.1.330.post0"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.329-py3-none-any.whl", hash = "sha256:c16f88a7ac14ddd0513e62fec56d69c37e3c6b412161ad16aa23a9c7e3dabaf4"},
-    {file = "pyright-1.1.329.tar.gz", hash = "sha256:5baf82ff5ecb8c8b3ac400e8536348efbde0b94a09d83d5b440c0d143fd151a8"},
+    {file = "pyright-1.1.330.post0-py3-none-any.whl", hash = "sha256:2e9e0878298685b66485b340a0aaa16342129eb03ff9ed0e3c1ab66b8bfbe914"},
+    {file = "pyright-1.1.330.post0.tar.gz", hash = "sha256:8e5b09cc5d1cfa0bcbf8824b0316d21c43fe229da7cef0a09cd12fcf6cb3eedd"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -556,13 +556,13 @@ pytest = "*"
 
 [[package]]
 name = "pytest-timeout"
-version = "2.1.0"
+version = "2.2.0"
 description = "pytest plugin to abort hanging tests"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-timeout-2.1.0.tar.gz", hash = "sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9"},
-    {file = "pytest_timeout-2.1.0-py3-none-any.whl", hash = "sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6"},
+    {file = "pytest-timeout-2.2.0.tar.gz", hash = "sha256:3b0b95dabf3cb50bac9ef5ca912fa0cfc286526af17afc806824df20c2f72c90"},
+    {file = "pytest_timeout-2.2.0-py3-none-any.whl", hash = "sha256:bde531e096466f49398a59f2dde76fa78429a09a12411466f88a07213e220de2"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,19 @@ strict = [
   "shellous/*.py",
 ]
 
+# Enable other pyright checks, not enabled by `strict`.
+# https://github.com/microsoft/pyright/blob/main/docs/configuration.md#diagnostic-rule-defaults
+
+reportCallInDefaultInitializer = true
+# reportImplicitOverride = true
+reportImplicitStringConcatenation = true
+# reportMissingSuperCall = true
+reportPropertyTypeMismatch = true
+reportShadowedImports = true
+reportUninitializedInstanceVariable = true
+reportUnnecessaryTypeIgnoreComment = true
+# reportUnusedCallResult = true
+
 [tool.black]
 required-version = "23.9.1"
 

--- a/shellous/__init__.py
+++ b/shellous/__init__.py
@@ -21,8 +21,8 @@ if sys.version_info[:3] in [(3, 10, 9), (3, 11, 1)]:
     # These releases have a known race condition.
     warnings.warn(  # pragma: no cover
         "Python 3.10.9 and Python 3.11.1 are unreliable with respect to "
-        "asyncio subprocesses. Consider a newer Python release: 3.10.10+ "
-        "or 3.11.2+. (https://github.com/python/cpython/issues/100133)",
+        + "asyncio subprocesses. Consider a newer Python release: 3.10.10+ "
+        + "or 3.11.2+. (https://github.com/python/cpython/issues/100133)",
         RuntimeWarning,
     )
 

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -62,7 +62,7 @@ _UNSET = _UnsetEnum.UNSET
 _T = TypeVar("_T")
 Unset = Union[_T, _UnsetEnum]
 
-_RedirectT = Any  # type: ignore
+_RedirectT = Any
 _PreexecFnT = Optional[Callable[[], None]]
 
 
@@ -719,7 +719,7 @@ class Command(Generic[_RT]):
 
     def __ror__(self, lhs: StdinType) -> "Command[_RT]":
         "Bitwise or operator is used to build pipelines."
-        if isinstance(lhs, STDIN_TYPES):
+        if isinstance(lhs, STDIN_TYPES):  # pyright: ignore[reportUnnecessaryIsInstance]
             return self.stdin(lhs)
         return NotImplemented
 

--- a/shellous/pipeline.py
+++ b/shellous/pipeline.py
@@ -147,12 +147,14 @@ class Pipeline(Generic[_RT]):
         return NotImplemented
 
     def __ror__(self, lhs: StdinType) -> "Pipeline[_RT]":
-        if isinstance(lhs, STDIN_TYPES):
+        if isinstance(lhs, STDIN_TYPES):  # pyright: ignore[reportUnnecessaryIsInstance]
             return self.stdin(lhs)
         return NotImplemented
 
     def __rshift__(self, rhs: StdoutType) -> "Pipeline[_RT]":
-        if isinstance(rhs, STDOUT_TYPES):
+        if isinstance(
+            rhs, STDOUT_TYPES
+        ):  # pyright: ignore[reportUnnecessaryIsInstance]
             return self.stdout(rhs, append=True)
         if isinstance(rhs, (str, bytes)):
             raise TypeError(

--- a/shellous/prompt.py
+++ b/shellous/prompt.py
@@ -1,8 +1,9 @@
 "Implements the Prompt utility class."
 
 import asyncio
+import enum
 import re
-from typing import Optional
+from typing import Optional, Union
 
 from shellous.harvest import harvest_results
 from shellous.log import LOG_DETAIL, LOGGER
@@ -12,25 +13,37 @@ from shellous.util import decode_bytes, encode_bytes
 _EOL_REGEX = re.compile(rb"\r\n|\r")
 
 
+class _Cue(enum.Enum):
+    "Alternate prompt types."
+    DEFAULT = enum.auto()
+    EOF = enum.auto()
+
+
 class Prompt:
     """Utility class to help with an interactive prompt session.
 
-    This is an experimental API.
+    This is an **experimental** API.
+
+    - A `prompt` is a text string that marks the end of some output, and
+      indicates that some new input is desired. In an interactive python
+      session, the prompt is typically ">>> ".
 
     Example:
     ```
     cmd = sh("sh").stdin(sh.CAPTURE).stdout(sh.CAPTURE).stderr(sh.STDOUT)
 
     async with cmd.env(PS1="??? ") as run:
-        prompt = Prompt(run, "??? ")
-        greeting = await prompt.receive()
+        cli = Prompt(run, prompt="??? ")
+        greeting = await cli.receive()
 
-        result = await prompt.send("echo hello")
+        result = await cli.send("echo hello")
         assert result == "hello\n"
 
-        prompt.close()
+        cli.close()
     ```
     """
+
+    EOF = _Cue.EOF
 
     _runner: Runner
     _encoding: str
@@ -42,7 +55,8 @@ class Prompt:
         self,
         runner: Runner,
         *,
-        default_prompt: str,
+        default_end: str = "\n",
+        default_prompt: str = "",
         default_timeout: Optional[float] = None,
         normalize_newlines: bool = False,
     ):
@@ -51,6 +65,7 @@ class Prompt:
 
         self._runner = runner
         self._encoding = runner.command.options.encoding
+        self._default_end = default_end
         self._default_prompt = encode_bytes(default_prompt, self._encoding)
         self._default_timeout = default_timeout
         self._normalize_newlines = normalize_newlines
@@ -59,20 +74,29 @@ class Prompt:
         self,
         input_text: str,
         *,
+        end: Optional[str] = None,
+        prompt: Union[str, _Cue, None] = _Cue.DEFAULT,
         timeout: Optional[float] = None,
+        delay: Optional[float] = None,
     ) -> str:
-        "Write some input text to stdin, then await the response from stdout."
+        """Write some input text to stdin, then await the response from stdout."""
         stdin = self._runner.stdin
         assert stdin is not None
 
-        data = encode_bytes(input_text, self._encoding) + b"\n"
+        if end is None:
+            end = self._default_end
+
+        if delay is not None:
+            await asyncio.sleep(delay)
+
+        data = encode_bytes(input_text + end, self._encoding)
         if LOG_DETAIL:
             LOGGER.debug("Prompt[pid=%s] send: %r", self._runner.pid, data)
         stdin.write(data)
 
         # Drain our write to stdin and wait for prompt from stdout.
         cancelled, (result, _) = await harvest_results(
-            self._read_to_prompt(),
+            self._read_to_prompt(prompt),
             stdin.drain(),
             timeout=timeout or self._default_timeout,
         )
@@ -85,11 +109,12 @@ class Prompt:
     async def receive(
         self,
         *,
+        prompt: Union[str, _Cue] = _Cue.DEFAULT,
         timeout: Optional[float] = None,
     ) -> str:
-        "Read from stdout up to the next prompt."
+        """Read from stdout up to the next prompt, or EOF if prompt not found."""
         cancelled, (result,) = await harvest_results(
-            self._read_to_prompt(),
+            self._read_to_prompt(prompt),
             timeout=timeout or self._default_timeout,
         )
         if cancelled:
@@ -98,27 +123,83 @@ class Prompt:
         assert isinstance(result, str)
         return result
 
+    async def expect(
+        self,
+        pattern: re.Pattern[str],
+        *,
+        timeout: Optional[float] = None,
+    ) -> tuple[str, re.Match[str]]:
+        """Read from stdout until the regular expression matches.
+
+        Use the `expect` method when you need to read up to a prompt that
+        varies.
+
+        ```python
+        _, m = await cli.expect(re.compile(r'Login: |Password: |ftp> '))
+        match m[0]:
+            case "Login: ":
+                await cli.send(user, prompt=None)
+            case "Password: ":
+                await cli.send(password, prompt=None)
+            case "ftp> ":
+                result = await cli.send(command)
+        ```
+        """
+        ...  # TODO
+
     def close(self) -> None:
         "Close stdin to end the prompt session."
         assert self._runner.stdin is not None
         self._runner.stdin.close()
 
-    async def _read_to_prompt(self) -> str:
+    async def _read_to_prompt(self, prompt: Union[str, _Cue, None]) -> str:
         "Read all data up to the prompt and return it (after removing prompt)."
+        if not prompt:
+            return ""
+
+        if prompt == _Cue.EOF:
+            return await self._read_to_eof()
+
+        if prompt == _Cue.DEFAULT:
+            prompt_bytes = self._default_prompt
+        else:
+            prompt_bytes = encode_bytes(prompt, self._encoding)
+
+        # If the prompt is "", do not read *anything*.
+        if not prompt_bytes:
+            return ""
+
         stdout = self._runner.stdout
         assert stdout is not None
 
-        buf = await _read_until(stdout, self._default_prompt)
+        buf = await _read_until(stdout, prompt_bytes)
         if LOG_DETAIL:
             LOGGER.debug("Prompt[pid=%s] receive: %r", self._runner.pid, buf)
 
         # Replace CR-LF or CR with LF.
         if self._normalize_newlines:
-            buf = _EOL_REGEX.sub(b"\n", buf)
+            buf = _normalize_eol(buf)
+
+        # TODO: Test case where prompt itself contains a CR-LF...
 
         # Clean up the output to remove the prompt, then return as string.
-        if buf.endswith(self._default_prompt):
-            buf = buf[0 : -len(self._default_prompt)]
+        if buf.endswith(prompt_bytes):
+            buf = buf[0 : -len(prompt_bytes)]
+
+        return decode_bytes(buf, self._encoding)
+
+    async def _read_to_eof(self) -> str:
+        "Read all data to the end."
+        stdout = self._runner.stdout
+        assert stdout is not None
+
+        buf = await stdout.read()
+        if LOG_DETAIL:
+            LOGGER.debug("Prompt[pid=%s] receive: %r", self._runner.pid, buf)
+
+        # Replace CR-LF or CR with LF.
+        if self._normalize_newlines:
+            buf = _normalize_eol(buf)
 
         return decode_bytes(buf, self._encoding)
 
@@ -133,6 +214,13 @@ async def _read_until(stream: asyncio.StreamReader, separator: bytes) -> bytes:
     except asyncio.LimitOverrunError as ex:
         # Okay, we have to buffer.
         buf = bytearray(await stream.read(ex.consumed))
+    except asyncio.CancelledError:
+        if LOG_DETAIL:
+            LOGGER.debug(
+                "Prompt._read_until cancelled with buffer contents: %r",
+                stream._buffer,
+            )
+        raise
 
     while True:
         try:
@@ -145,3 +233,8 @@ async def _read_until(stream: asyncio.StreamReader, separator: bytes) -> bytes:
         break
 
     return bytes(buf)
+
+
+def _normalize_eol(buf: bytes) -> bytes:
+    """Normalize end of lines."""
+    return _EOL_REGEX.sub(b"\n", buf)

--- a/shellous/prompt.py
+++ b/shellous/prompt.py
@@ -149,8 +149,16 @@ class Prompt:
 
     def close(self) -> None:
         "Close stdin to end the prompt session."
-        assert self._runner.stdin is not None
-        self._runner.stdin.close()
+        stdin = self._runner.stdin
+        assert stdin is not None
+
+        if self._runner.pty_eof is not None:
+            assert self._runner.pty_eof
+            # Write EOF twice; once to end the current line, and the second
+            # time to signal the end.
+            stdin.write(self._runner.pty_eof * 2)
+        else:
+            stdin.close()
 
     async def _read_to_prompt(self, prompt: Union[str, _Cue, None]) -> str:
         "Read all data up to the prompt and return it (after removing prompt)."

--- a/shellous/pty_util.py
+++ b/shellous/pty_util.py
@@ -218,13 +218,19 @@ def cooked(
         if rows_int or cols_int:
             _set_term_size(fdesc, rows_int, cols_int)
         if not echo:
-            _set_term_echo(fdesc, False)
+            set_term_echo(fdesc, False)
         assert _get_eof(fdesc) == b"\x04"
 
     return _pty_set_canonical
 
 
-def _set_term_echo(fdesc: int, echo: bool):
+def get_term_echo(fdesc: int) -> bool:
+    "Return true if terminal driver is in echo mode."
+    attrs = termios.tcgetattr(fdesc)
+    return (attrs[_LFLAG] & termios.ECHO) != 0
+
+
+def set_term_echo(fdesc: int, echo: bool):
     "Set pseudo-terminal echo."
     attrs = termios.tcgetattr(fdesc)
     curr_echo = (attrs[_LFLAG] & termios.ECHO) != 0

--- a/shellous/pty_util.py
+++ b/shellous/pty_util.py
@@ -174,7 +174,7 @@ async def _open_pty_streams(parent_fd: int, child_fd: ChildFd):
         _orig_close()
         reader_transport.close()
 
-    writer_transport.close, _orig_close = _close, writer_transport.close  # type: ignore
+    writer_transport.close, _orig_close = _close, writer_transport.close
 
     return reader, writer
 

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -117,7 +117,7 @@ class _RunOptions:
             # If executable does not include an absolute/relative directory,
             # resolve it using PATH.
             executable = self.pos_args[0]
-            if not os.path.dirname(executable):  # type: ignore (path)
+            if not os.path.dirname(executable):
                 found_executable = _cmd.options.which(executable)
                 if found_executable is None:
                     raise FileNotFoundError(executable)
@@ -266,7 +266,7 @@ class _RunOptions:
         input_bytes = None
 
         if isinstance(input_, (bytes, bytearray)):
-            input_bytes = input_
+            input_bytes = bytes(input_)
         elif isinstance(input_, Path):
             stdin = open(input_, "rb")  # pylint: disable=consider-using-with
             self.open_fds.append(stdin)

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -451,6 +451,28 @@ class Runner:
         "Return True if the command was cancelled."
         return self._cancelled
 
+    @property
+    def pty_fd(self) -> Optional[int]:
+        """The file descriptor used to communicate with the child PTY process.
+
+        Returns None if the process is not using a PTY.
+        """
+        pty_fds = self._options.pty_fds
+        if pty_fds is not None:
+            return pty_fds.parent_fd
+        return None
+
+    @property
+    def pty_eof(self) -> Optional[bytes]:
+        """Byte sequence used to indicate EOF when written to the PTY child.
+
+        Returns None if process is not using a PTY.
+        """
+        pty_fds = self._options.pty_fds
+        if pty_fds is not None:
+            return pty_fds.eof
+        return None
+
     def result(self) -> Result:
         "Check process exit code and raise a ResultError if necessary."
         code = self.returncode

--- a/shellous/util.py
+++ b/shellous/util.py
@@ -26,7 +26,7 @@ _ContextKey = tuple[int, int]
 
 # Stores current stack of context managers for immutable Command objects.
 _CONTEXT_STACKS = contextvars.ContextVar[
-    dict[_ContextKey, list[AsyncContextManager[_T]]]
+    dict[_ContextKey, list[AsyncContextManager[Any]]]
 ]("shellous.context_stacks")
 
 # True if OS is derived from BSD.
@@ -92,7 +92,7 @@ def wait_pid(pid: int, *, block: bool = False) -> Optional[int]:
 
     try:
         # os.WNOHANG is not available on Windows.
-        options = 0 if block else os.WNOHANG  # type: ignore
+        options = 0 if block else os.WNOHANG
         result_pid, status = os.waitpid(pid, options)
     except ChildProcessError as ex:
         # Set status to 255 if process not found.
@@ -107,7 +107,7 @@ def wait_pid(pid: int, *, block: bool = False) -> Optional[int]:
 
     # Convert os.waitpid status to an exit status.
     try:
-        status = os.waitstatus_to_exitcode(status)  # type: ignore
+        status = os.waitstatus_to_exitcode(status)
     except ValueError:  # pragma: no cover
         # waitstatus_to_exitcode can theoretically raise a ValueError if
         # the status is not understood. In this case, we do what

--- a/shellous/watcher.py
+++ b/shellous/watcher.py
@@ -174,7 +174,7 @@ class KQueueStrategy(ChildStrategy):
 
     def close(self) -> None:
         "Tell our thread to exit with a dummy timer event."
-        self._add_kevent(1, select.KQ_FILTER_TIMER)  # type: ignore
+        self._add_kevent(1, select.KQ_FILTER_TIMER)
         self._thread.join()
 
     def watch_pid(
@@ -188,7 +188,7 @@ class KQueueStrategy(ChildStrategy):
         self._pids[pid] = (callback, args)  # ATOMIC: self._pids[] = ...
 
         try:
-            self._add_kevent(pid, select.KQ_FILTER_PROC, select.KQ_NOTE_EXIT)  # type: ignore
+            self._add_kevent(pid, select.KQ_FILTER_PROC, select.KQ_NOTE_EXIT)
             LOGGER.debug("_add_kevent pid=%r", pid)
         except ProcessLookupError:
             self._kevent_failed(pid)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -50,7 +50,11 @@ async def test_prompt_python_pty():
     cmd = sh(sys.executable).stdin(sh.CAPTURE).stdout(sh.CAPTURE).stderr(sh.STDOUT)
 
     async with cmd.set(pty=_NO_ECHO) as run:
-        repl = Prompt(run, _PS1, default_timeout=3.0)
+        repl = Prompt(
+            run,
+            default_prompt=_PS1,
+            default_timeout=3.0,
+        )
 
         greeting = await repl.receive()
         assert "Python" in greeting
@@ -73,7 +77,12 @@ async def test_prompt_python_interactive():
     )
 
     async with cmd as run:
-        repl = Prompt(run, _PS1, default_timeout=3.0, normalize_newlines=True)
+        repl = Prompt(
+            run,
+            default_prompt=_PS1,
+            default_timeout=3.0,
+            normalize_newlines=True,
+        )
 
         greeting = await repl.receive()
         assert "Python" in greeting
@@ -94,7 +103,7 @@ async def test_prompt_python_interactive_ps1():
     )
 
     async with cmd as run:
-        repl = Prompt(run, alt_ps1, normalize_newlines=True)
+        repl = Prompt(run, default_prompt=alt_ps1, normalize_newlines=True)
 
         greeting = await repl.send(f"import sys; sys.ps1='{alt_ps1}'")
         assert _PS1 in greeting
@@ -115,7 +124,7 @@ async def test_prompt_python_timeout():
     )
 
     async with cmd as run:
-        repl = Prompt(run, _PS1)
+        repl = Prompt(run, default_prompt=_PS1)
 
         greeting = await repl.receive()
         assert "Python" in greeting
@@ -135,7 +144,7 @@ async def test_prompt_python_missing_newline():
     )
 
     async with cmd as run:
-        repl = Prompt(run, _PS1, normalize_newlines=True)
+        repl = Prompt(run, default_prompt=_PS1, normalize_newlines=True)
 
         greeting = await repl.receive()
         assert "Python" in greeting
@@ -160,7 +169,7 @@ async def test_prompt_unix_shell():
     )
 
     async with cmd.env(PS1="$", TERM="dumb") as run:
-        repl = Prompt(run, "$")
+        repl = Prompt(run, default_prompt="$")
 
         greeting = await repl.receive()
         if _IS_FREEBSD:
@@ -193,7 +202,7 @@ async def test_prompt_unix_shell_echo():
     )
 
     async with cmd.env(PS1="$", TERM="dumb") as run:
-        repl = Prompt(run, "$")
+        repl = Prompt(run, default_prompt="$")
 
         greeting = await repl.receive()
         if _IS_FREEBSD:
@@ -226,7 +235,7 @@ async def test_prompt_unix_shell_interactive():
     )
 
     async with cmd.env(PS1="$", TERM="dumb") as run:
-        repl = Prompt(run, "$")
+        repl = Prompt(run, default_prompt="$")
 
         greeting = await repl.receive()
         assert "job control" in greeting  # expect message about job control
@@ -256,7 +265,7 @@ async def test_prompt_asyncio_repl():
     )
 
     async with cmd as run:
-        repl = Prompt(run, ">>> ", normalize_newlines=True)
+        repl = Prompt(run, default_prompt=">>> ", normalize_newlines=True)
 
         greeting = await repl.receive()
         assert "asyncio" in greeting

--- a/tests/test_pytest.py
+++ b/tests/test_pytest.py
@@ -1,8 +1,15 @@
 "Unit tests for using shellous commands in a pytest fixture."
 
+import os
+
 import pytest
 
 from shellous import Runner, sh
+
+
+def _coverage():
+    "Return true if we are running under coverage."
+    return os.environ.get("COVERAGE_RUN", None) is not None
 
 
 @pytest.fixture
@@ -16,6 +23,7 @@ async def echo_broken():
         yield run
 
 
+@pytest.mark.skipif(_coverage(), reason="coverage")
 @pytest.mark.xfail(raises=RuntimeError)
 async def test_echo_broken(echo_broken):
     assert echo_broken.command.args[0] == "echo"

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -27,7 +27,12 @@ async def run_asyncio_repl(cmds, logfile=None):
     )
 
     async with repl as run:
-        prompt = Prompt(run, _PROMPT, default_timeout=5.0, normalize_newlines=True)
+        prompt = Prompt(
+            run,
+            default_prompt=_PROMPT,
+            default_timeout=5.0,
+            normalize_newlines=True,
+        )
 
         # Customize the python REPL prompt to make it easier to detect. The
         # initial output of the REPL will include the old ">>> " prompt which

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -926,10 +926,13 @@ async def test_redirect_to_arbitrary_tuple():
 async def test_command_context_manager_default():
     "Test running a command using its context manager."
     async with sh("echo", "hello") as run:
-        # By default, context manager does not capture any streams.
+        # By default, context manager does not capture any streams,
+        # and we're not in a PTY.
         assert run.stdin is None
         assert run.stdout is None
         assert run.stderr is None
+        assert run.pty_fd is None
+        assert run.pty_eof is None
 
     assert run.result().output == "hello\n"
 

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -917,10 +917,10 @@ async def test_pty_echo_exit_code(echo_cmd):
 async def test_redirect_to_arbitrary_tuple():
     "Test redirection to an arbitrary tuple."
     with pytest.raises(TypeError, match="unsupported"):
-        await sh("echo").stdout((1, 2))  # type: ignore
+        await sh("echo").stdout((1, 2))
 
     with pytest.raises(TypeError, match="unsupported"):
-        await (sh("echo") | (1, 2))  # type: ignore
+        await (sh("echo") | (1, 2))  # pyright: ignore[reportGeneralTypeIssues]
 
 
 async def test_command_context_manager_default():

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -147,7 +147,7 @@ async def test_bulk_prompt(bulk_cmd, _limit_logging):
     cmd = bulk_cmd().set(encoding="latin1")
 
     async with cmd.stdin(sh.CAPTURE).stdout(sh.CAPTURE) as run:
-        prompt = Prompt(run, ">>> ")
+        prompt = Prompt(run, default_prompt=">>> ")
         result = await prompt.receive(timeout=10.0)
         assert len(result) == 4 * (1024 * 1024 + 1)
         value = hashlib.sha256(result.encode("latin1")).hexdigest()

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -1036,7 +1036,13 @@ async def test_pty():
         run.stdin.close()
 
     assert result == b"abc\r\nABC\r\n"
-    assert run.result().exit_code == -1
+
+    # Exit code of PTY process differs on FreeBSD...
+    exit_status = run.result().exit_code
+    if sys.platform.startswith("freebsd"):
+        assert exit_status == 0
+    else:
+        assert exit_status == -1
 
 
 @pytest.mark.skipif(_is_uvloop(), reason="uvloop")

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -610,9 +610,10 @@ async def test_pipeline_async_context_manager():
     assert result == b"A"
     assert run.name == "tr|cat"
     assert (
-        repr(run) == "<PipeRunner 'tr|cat' results=["
-        "Result(exit_code=0, output_bytes=b'', error_bytes=b'', cancelled=False, encoding='utf-8'), "
-        "Result(exit_code=0, output_bytes=b'', error_bytes=b'', cancelled=False, encoding='utf-8')]>"
+        repr(run)
+        == "<PipeRunner 'tr|cat' results=["
+        + "Result(exit_code=0, output_bytes=b'', error_bytes=b'', cancelled=False, encoding='utf-8'), "
+        + "Result(exit_code=0, output_bytes=b'', error_bytes=b'', cancelled=False, encoding='utf-8')]>"
     )
 
 


### PR DESCRIPTION
- Prompt class `default_prompt` initializer is now a keyword-only argument. 
- Add `default_end` option to Prompt initializer.
- Add `run` and `echo` properties to Prompt class.
- Add pty_fd and pty_eof properties to Runner class.
- Prompt class can now receive all data up to EOF using a special enum.
- Add `noecho` option to `Prompt.send()` method.