### PR TITLE
API changes in Prompt class. Supports regular expression matching for the prompt.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "python.formatting.provider": "black",
+    "python.formatting.provider": "none",
     "python.testing.pytestArgs": [
         "."
     ],
@@ -8,6 +8,8 @@
     "[python]": {
         "editor.codeActionsOnSave": {
             "source.organizeImports": true
-        }
+        },
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.formatOnSave": true
     }
 }

--- a/shellous/prompt.py
+++ b/shellous/prompt.py
@@ -63,6 +63,7 @@ class Prompt:
     _default_prompt: bytes
     _default_timeout: Optional[float]
     _normalize_newlines: bool
+    _chunk_size: int
     _decoder: codecs.IncrementalDecoder
     _pending: str = ""
     _at_eof: bool = False
@@ -75,6 +76,7 @@ class Prompt:
         default_prompt: str = "",
         default_timeout: Optional[float] = None,
         normalize_newlines: bool = False,
+        chunk_size: int = 4096,
     ):
         assert runner.stdin is not None
         assert runner.stdout is not None
@@ -85,6 +87,7 @@ class Prompt:
         self._default_prompt = encode_bytes(default_prompt, self._encoding)
         self._default_timeout = default_timeout
         self._normalize_newlines = normalize_newlines
+        self._chunk_size = chunk_size
         self._decoder = _get_decoder(self._encoding, normalize_newlines)
 
     @property
@@ -308,6 +311,7 @@ class Prompt:
         """
         stdout = self._runner.stdout
         assert stdout is not None
+        assert self._chunk_size > 0
 
         while True:
             assert not self._at_eof
@@ -315,7 +319,7 @@ class Prompt:
             _initial_len = len(self._pending)
 
             # Read chunk and check for EOF.
-            chunk = await stdout.read(4096)
+            chunk = await stdout.read(self._chunk_size)
             if not chunk:
                 self._at_eof = True
 

--- a/tests/prompt/example1.py
+++ b/tests/prompt/example1.py
@@ -19,18 +19,17 @@ async def main():
     cmd = sh(_DIR / "fake_prompter.sh", opts).stdin(sh.CAPTURE).stdout(sh.CAPTURE)
 
     async with cmd.set(pty=True) as run:
-        cli = Prompt(
-            run,
-            default_prompt="prompt> ",
-            default_timeout=10.0,
-        )
+        cli = Prompt(run, default_timeout=10.0)
 
-        await cli.receive(prompt="Name: ")
-        await cli.send("friend", prompt="Password: ")
-        await cli.send("abc123", noecho=True)
+        await cli.expect("Name: ")
+        await cli.send("friend")
+        await cli.expect("Password: ")
+        await cli.send("abc123", no_echo=True)
+        await cli.expect("prompt> ")
 
         # Send a command and print the response.
-        response = await cli.send("arbitrary")
+        await cli.send("arbitrary")
+        response, _ = await cli.expect("prompt> ")
         print(response)
 
         cli.close()

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -37,6 +37,9 @@ else:
 
 _NO_ECHO = cooked(echo=False)
 
+# Alpine is including some terminal escapes.
+_TERM_ESCAPES = "\x1b[6n" if _IS_ALPINE else ""
+
 _requires_unix = pytest.mark.skipif(sys.platform == "win32", reason="requires unix")
 
 _requires_pty = pytest.mark.skipif(
@@ -247,14 +250,12 @@ async def test_prompt_unix_shell_echo():
             assert "job control" in greeting
         else:
             assert greeting == ""
-        assert repl.pending == ""
+
+        # Alpine is including terminal escape chars.
+        assert repl.pending == f"{_TERM_ESCAPES}"
 
         result = await repl.command("echo 123")
-        if _IS_ALPINE:
-            # Alpine is including terminal escape chars.
-            assert result == "\x1b[6necho 123\r\n123\r\n"
-        else:
-            assert result == "echo 123\r\n123\r\n"
+        assert result == f"{_TERM_ESCAPES}echo 123\r\n123\r\n"
 
         await repl.command("exit")
         assert repl.at_eof
@@ -344,14 +345,12 @@ async def test_prompt_unix_eof():
             assert "job control" in greeting
         else:
             assert greeting == ""
-        assert repl.pending == ""
+
+        # Alpine is including terminal escape chars.
+        assert repl.pending == f"{_TERM_ESCAPES}"
 
         result = await repl.command("echo 123")
-        if _IS_ALPINE:
-            # Alpine is including terminal escape chars.
-            assert result == "\x1b[6necho 123\r\n123\r\n"
-        else:
-            assert result == "echo 123\r\n123\r\n"
+        assert result == f"{_TERM_ESCAPES}echo 123\r\n123\r\n"
 
         repl.close()  # In PTY mode, this sends ^D to close....
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -377,3 +377,35 @@ async def test_prompt_asyncio_repl_expect():
         assert x is None
 
     assert run.result().exit_code == 0
+
+
+async def test_prompt_python_ps1_unicode():
+    "Test the Python REPL but change the prompt to an Emoji. Use chunk_size=1."
+    ps1 = "<<\U0001F603>>"
+    ps1_esc = _escape(ps1)
+
+    cmd = (
+        sh(sys.executable, "-i").stdin(sh.CAPTURE).stdout(sh.CAPTURE).stderr(sh.STDOUT)
+    )
+
+    prompt = re.compile(ps1)
+
+    async with cmd as run:
+        repl = Prompt(run, normalize_newlines=True, chunk_size=1)
+
+        await repl.send(f"import sys; sys.ps1='{ps1_esc}'", timeout=3.0)
+        greeting, m = await repl.expect(prompt)
+        assert _PS1 in greeting
+        assert m[0] == ps1
+
+        await repl.send("print('def')")
+        result, m = await repl.expect(prompt)
+        assert result == "def\n"
+        assert m[0] == ps1
+
+        await repl.send("exit()")
+        result, m = await repl.expect(None)
+        assert result == ""
+        assert m is None
+
+    assert run.result().exit_code == 0

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -404,8 +404,7 @@ async def test_prompt_python_ps1_unicode():
         assert m[0] == ps1
 
         await repl.send("exit()")
-        result, m = await repl.expect(None)
+        result = await repl.read_all()
         assert result == ""
-        assert m is None
 
     assert run.result().exit_code == 0

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -37,23 +37,23 @@ async def run_asyncio_repl(cmds, logfile=None):
         # Customize the python REPL prompt to make it easier to detect. The
         # initial output of the REPL will include the old ">>> " prompt which
         # we can ignore.
-        await prompt.send(f"import sys; sys.ps1 = '{_PROMPT}'; sys.ps2 = ''")
+        await prompt.command(f"import sys; sys.ps1 = '{_PROMPT}'; sys.ps2 = ''")
 
         # Optionally redirect logging to a file.
-        await prompt.send("import shellous.log, logging")
+        await prompt.command("import shellous.log, logging")
         if logfile:
-            await prompt.send("shellous.log.LOGGER.setLevel(logging.DEBUG)")
-            await prompt.send(
+            await prompt.command("shellous.log.LOGGER.setLevel(logging.DEBUG)")
+            await prompt.command(
                 f"logging.basicConfig(filename='{logfile}', level=logging.DEBUG)"
             )
         else:
             # I don't want random logging messages to confuse the output.
-            await prompt.send("shellous.log.LOGGER.setLevel(logging.ERROR)")
+            await prompt.command("shellous.log.LOGGER.setLevel(logging.ERROR)")
 
         output = []
         for cmd in cmds:
             LOGGER.info("  repl: %r", cmd)
-            out = await prompt.send(cmd)
+            out = await prompt.command(cmd)
             output.append(out.rstrip("\n"))
             # Give tasks a chance to get started.
             if ".create_task(" in cmd:

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -148,7 +148,7 @@ async def test_bulk_prompt(bulk_cmd, _limit_logging):
 
     async with cmd.stdin(sh.CAPTURE).stdout(sh.CAPTURE) as run:
         prompt = Prompt(run, default_prompt=">>> ")
-        result = await prompt.receive(timeout=10.0)
+        result = await prompt.read_all(timeout=10.0)
         assert len(result) == 4 * (1024 * 1024 + 1)
         value = hashlib.sha256(result.encode("latin1")).hexdigest()
         assert (


### PR DESCRIPTION
The send() method no longer returns the next bunch of data. Use the command() method instead.
The receive() method has been removed. Use the expect() method instead.
Rename the `noecho` argument to `no_echo`.