### PR TITLE
Improve Prompt tests; add CI support for FreeBSD 14.0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,12 +9,12 @@ freebsd_task:
     SHELLOUS_DEBUG: 1
 
   matrix:
+    - name: FreeBSD 14.0
+      freebsd_instance:
+        image_family: freebsd-14-0
     - name: FreeBSD 13.2
       freebsd_instance:
         image_family: freebsd-13-2
-    - name: FreeBSD 13.1
-      freebsd_instance:
-        image_family: freebsd-13-1
     - name: FreeBSD 12.4
       freebsd_instance:
         image_family: freebsd-12-4
@@ -28,10 +28,6 @@ freebsd_task:
 
   script:
     - . .venv/bin/activate && pytest -vv -s --durations=20 --log-cli-level=DEBUG
-
-  safecw_script:
-    # Test SafeChildWatcher.
-    - . .venv/bin/activate && SHELLOUS_CHILDWATCHER_TYPE=safe pytest -vv -s --durations=20 --log-cli-level=DEBUG
 
   defaultcw_script:
     # Test DefaultChildWatcher.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,6 @@ jobs:
 
     env:
       SHELLOUS_DEBUG: 1
-      BUILD_NAME: build (${{ matrix.pypy-version }})
 
     steps:
     - name: Harden Runner
@@ -207,3 +206,27 @@ jobs:
         pytest -vv -s --log-cli-level=DEBUG -W ignore::pytest.PytestUnraisableExceptionWarning
       env:
         SHELLOUS_CHILDWATCHER_TYPE: "default"
+
+  build-13:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20  # stop runaway job after 20 minutes
+    env:
+      SHELLOUS_DEBUG: 1
+
+    steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+      with:
+        egress-policy: audit
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Set up Python 3.13
+      uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
+      with:
+        python-version: '3.13-dev'
+    - name: Install dependencies
+      run: |
+        pip3 install --require-hashes -r ./ci/requirements-dev.txt
+    - name: Run Tests
+      run: |
+        pytest -vv -s --log-cli-level=DEBUG

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,10 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-filterwarnings = [
-  "error",
-  'ignore:.*(ChildWatcher|get_child_watcher|set_child_watcher|deprecated and will be removed in Python 3.14):DeprecationWarning',  # 3.12
-]
+#filterwarnings = [
+#  "error",
+#  'ignore:.*(ChildWatcher|get_child_watcher|set_child_watcher):DeprecationWarning',
+#]
 env_files = ["tests/tests.env"]
 addopts = '--timeout=20 --color=yes --log-cli-format="%(created).03f %(levelname)s %(name)s %(message)s" --log-level=INFO --log-file-format="%(created).03f %(levelname)s %(name)s %(message)s"'
 asyncio_mode = "auto"

--- a/shellous/prompt.py
+++ b/shellous/prompt.py
@@ -21,23 +21,22 @@ _LOG_LIMIT = 2000
 class Prompt:
     """Utility class to help with an interactive prompt session.
 
-    This is an **experimental** API.
+    When you are controlling to a co-process you will usually `send` some
+    text to it, and then `expect` a response. The `expect` operation can use
+    a regular expression to match different types of responses.
 
-    - A `prompt` is a text string that marks the end of some output, and
-      indicates that some new input is desired. In an interactive python
-      session, the prompt is typically ">>> ".
+    Create a new `Prompt` instance using the `prompt()` API.
 
-    You will usually create a `Prompt` class using the `prompt()` API.
-
-    Example:
     ```
+    # In this example, we are using a default prompt of "??? ".
+    # Setting PS1 tells the shell to use this as the shell prompt.
     cmd = sh("sh").env(PS1="??? ").set(pty=True)
 
     async with cmd.prompt("??? ", timeout=3.0) as cli:
         # Turn off terminal echo.
         cli.echo = False
 
-        # Wait for initial prompt.
+        # Wait for greeting and initial prompt.
         greeting, _ = await cli.expect()
 
         # Send a command and wait for the response.
@@ -102,9 +101,12 @@ class Prompt:
 
     @property
     def echo(self) -> bool:
-        """True if TTY is in echo mode.
+        """True if PTY is in echo mode.
 
-        If the runner is not using a PTY, return False.
+        If the runner is not using a PTY, always return False.
+
+        When the process is using a PTY, you can enable/disable echo mode by
+        setting `.echo` to True/False.
         """
         if self._runner.pty_fd is None:
             return False
@@ -227,6 +229,8 @@ class Prompt:
         )
         if cancelled:
             raise asyncio.CancelledError()
+        if isinstance(result, Exception):
+            raise result
 
         return result
 

--- a/shellous/prompt.py
+++ b/shellous/prompt.py
@@ -127,6 +127,11 @@ class Prompt:
         "The `Result` of the command, or None if it has not exited yet."
         return self._result
 
+    @property
+    def runner(self) -> Runner:
+        "The process runner."
+        return self._runner
+
     async def send(
         self,
         input_text: Union[bytes, str],

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -42,12 +42,6 @@ _NO_ECHO = cooked(echo=False)
 # Alpine is including some terminal escapes.
 _TERM_ESCAPES = "\x1b[6n" if _IS_ALPINE else ""
 
-# Guess termios MAX_CANON for pty boundary testing.
-if _IS_FREEBSD or _IS_MACOS:
-    _MAX_CANON = os.fpathconf(0, "PC_MAX_CANON")
-else:
-    _MAX_CANON = 4096  # Linux
-
 _requires_unix = pytest.mark.skipif(sys.platform == "win32", reason="requires unix")
 
 _requires_pty = pytest.mark.skipif(
@@ -454,12 +448,21 @@ async def test_prompt_grep_pty():
     async with cmd.prompt() as cli:
         cli.echo = False
 
-        await cli.send("a" * (_MAX_CANON - 2) + "b")
+        # Determine MAX_CANON for the PTY.
+        fd = cli.runner.pty_fd
+        assert fd is not None
+        if _IS_FREEBSD or _IS_MACOS:
+            max_canon = os.fpathconf(fd, "PC_MAX_CANON")
+        else:
+            max_canon = 4096
+        print(f"using max_canon = {max_canon}")
+
+        await cli.send("a" * (max_canon - 2) + "b")
         _, m = await cli.expect(re.compile(r"b\r?\r\n"))  # MACOS: extra '\r' after 'b'?
-        assert m.start() == _MAX_CANON - 2
+        assert m.start() == max_canon - 2
         assert cli.pending == ""
 
-        await cli.send("a" * (_MAX_CANON - 1) + "b")
+        await cli.send("a" * (max_canon - 1) + "b")
         try:
             _, m = await cli.expect("\x07", timeout=2.0)  # \x07 is BEL
         except asyncio.TimeoutError:

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -43,7 +43,10 @@ _NO_ECHO = cooked(echo=False)
 _TERM_ESCAPES = "\x1b[6n" if _IS_ALPINE else ""
 
 # Guess termios MAX_CANON for pty boundary testing.
-_MAX_CANON = 1024 if _IS_FREEBSD or _IS_MACOS else 4096
+if _IS_FREEBSD or _IS_MACOS:
+    _MAX_CANON = os.fpathconf(0, "PC_MAX_CANON")
+else:
+    _MAX_CANON = 4096  # Linux
 
 _requires_unix = pytest.mark.skipif(sys.platform == "win32", reason="requires unix")
 

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -48,8 +48,7 @@ def _readouterr(capfd):
         "^\\d+\\.\\d+ \x1b\\[35mDEBUG\x1b\\[0m.*\n",
         "",
         out,
-        0,
-        re.MULTILINE,
+        flags=re.MULTILINE,
     )
     return (out, err)
 

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -1158,6 +1158,22 @@ _STTY_FREEBSD_13 = (
     b"\tstatus = ^T; stop = ^S; susp = ^Z; time = 0; werase = ^W;\r\n"
 )
 
+_STTY_FREEBSD_14 = (
+    b"speed 9600 baud; 0 rows; 0 columns;\r\n"
+    b"lflags: icanon isig iexten echo echoe -echok echoke -echonl echoctl\r\n"
+    b"\t-echoprt -altwerase -noflsh -tostop -flusho -pendin -nokerninfo\r\n"
+    b"\t-extproc\r\n"
+    b"iflags: -istrip icrnl -inlcr -igncr ixon -ixoff ixany imaxbel -ignbrk\r\n"
+    b"\tbrkint -inpck -ignpar -parmrk -iutf8\r\n"
+    b"oflags: opost onlcr -ocrnl tab0 -onocr -onlret\r\n"
+    b"cflags: cread cs8 -parenb -parodd hupcl -clocal -cstopb -crtscts -dsrflow\r\n"
+    b"\t-dtrflow -mdmbuf rtsdtr\r\n"
+    b"cchars: discard = ^O; dsusp = ^Y; eof = ^D; eol = <undef>;\r\n"
+    b"\teol2 = <undef>; erase = ^?; erase2 = ^H; intr = ^C; kill = ^U;\r\n"
+    b"\tlnext = ^V; min = 1; quit = ^\\; reprint = ^R; start = ^Q;\r\n"
+    b"\tstatus = ^T; stop = ^S; susp = ^Z; time = 0; werase = ^W;\r\n"
+)
+
 
 @pytest.mark.skipif(_is_uvloop() or _IS_ALPINE, reason="uvloop,alpine")
 async def test_pty_stty_all(tmp_path):
@@ -1181,7 +1197,7 @@ async def test_pty_stty_all(tmp_path):
     if sys.platform == "linux":
         assert buf == _STTY_LINUX
     elif sys.platform.startswith("freebsd"):
-        assert buf == _STTY_FREEBSD_12 or buf == _STTY_FREEBSD_13
+        assert buf in (_STTY_FREEBSD_12, _STTY_FREEBSD_13, _STTY_FREEBSD_14)
     else:
         assert buf == _STTY_DARWIN
 


### PR DESCRIPTION
- Add CI testing support for FreeBSD 14.0
- Add CI testing support for Python 3.13-dev (Linux)
- Add Prompt.runner property.
- Improve some Prompt tests.