### PR TITLE
Simplify Prompt API and add doc comments.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       env:
         SHELLOUS_CHILDWATCHER_TYPE: "default"
     - name: Verify Types
-      if: matrix.python-version != '3.13-dev'
+      if: matrix.python-version != '3.13-dev' && matrix.python-version != '3.9'
       run: |
         PYTHONPATH=. pyright --verifytypes shellous
     - name: Format Check

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -662,7 +662,6 @@ class Command(Generic[_RT]):
         self,
         prompt: Union[str, re.Pattern[str], None] = None,
         *,
-        end: Optional[str] = None,
         timeout: Optional[float] = None,
         normalize_newlines: bool = False,
         chunk_size: Optional[int] = None,
@@ -676,14 +675,12 @@ class Command(Generic[_RT]):
                 cli = Prompt(
                     run,
                     default_prompt=prompt,
-                    default_end=end,
                     default_timeout=timeout,
                     normalize_newlines=normalize_newlines,
                     chunk_size=chunk_size,
                 )
                 yield cli
                 cli.close()
-                # TODO: await cli.skip_all()
         finally:
             if cli is not None:
                 cli._finish_()  # pyright: ignore[reportPrivateUsage]

--- a/shellous/prompt.py
+++ b/shellous/prompt.py
@@ -48,7 +48,6 @@ class Prompt:
 
     _runner: Runner
     _encoding: str
-    _default_end: str
     _default_prompt: Optional[re.Pattern[str]]
     _default_timeout: Optional[float]
     _normalize_newlines: bool
@@ -62,7 +61,6 @@ class Prompt:
         self,
         runner: Runner,
         *,
-        default_end: Optional[str] = None,
         default_prompt: Union[str, re.Pattern[str], None] = None,
         default_timeout: Optional[float] = None,
         normalize_newlines: bool = False,
@@ -70,9 +68,6 @@ class Prompt:
     ):
         assert runner.stdin is not None
         assert runner.stdout is not None
-
-        if default_end is None:
-            default_end = _DEFAULT_LINE_END
 
         if chunk_size is None:
             chunk_size = _DEFAULT_CHUNK_SIZE
@@ -82,7 +77,6 @@ class Prompt:
 
         self._runner = runner
         self._encoding = runner.command.options.encoding
-        self._default_end = default_end
         self._default_prompt = default_prompt
         self._default_timeout = default_timeout
         self._normalize_newlines = normalize_newlines
@@ -136,14 +130,11 @@ class Prompt:
         self,
         input_text: Union[bytes, str],
         *,
-        end: Optional[str] = None,
+        end: str = _DEFAULT_LINE_END,
         no_echo: bool = False,
         timeout: Optional[float] = None,
     ) -> None:
         """Write some input text to stdin."""
-        if end is None:
-            end = self._default_end
-
         if no_echo:
             await self._wait_no_echo()
 
@@ -269,7 +260,7 @@ class Prompt:
         self,
         input_text: str,
         *,
-        end: Optional[str] = None,
+        end: str = _DEFAULT_LINE_END,
         no_echo: bool = False,
         prompt: Union[str, re.Pattern[str], None] = None,
         timeout: Optional[float] = None,

--- a/shellous/prompt.py
+++ b/shellous/prompt.py
@@ -312,7 +312,7 @@ class Prompt:
                 return result
 
         if self._at_eof:
-            raise EOFError("Prompt at EOF")
+            return ("", None)
 
         cancelled, (result,) = await harvest_results(
             self._read_to_pattern(prompt),
@@ -364,7 +364,7 @@ class Prompt:
     ) -> str:
         "Send some input and receive the response up to the next prompt."
         if self._at_eof:
-            raise EOFError("Prompt at EOF")
+            raise EOFError("Prompt has reached EOF already")
 
         await self.send(text, end=end, no_echo=no_echo, timeout=timeout)
         result, _ = await self.expect(prompt, timeout=timeout)

--- a/shellous/prompt.py
+++ b/shellous/prompt.py
@@ -4,7 +4,10 @@ import asyncio
 import codecs
 import io
 import re
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
+
+if TYPE_CHECKING:
+    from types import EllipsisType  # requires python 3.10
 
 from shellous import pty_util
 from shellous.harvest import harvest_results
@@ -179,7 +182,7 @@ class Prompt:
 
     async def expect(
         self,
-        prompt: Union[str, re.Pattern[str], None] = None,
+        prompt: Union[str, re.Pattern[str], "EllipsisType", None] = None,
         *,
         timeout: Optional[float] = None,
     ) -> tuple[str, Optional[re.Match[str]]]:
@@ -204,6 +207,9 @@ class Prompt:
                     await cli.send(command)
         ```
         """
+        if prompt is ...:
+            return await self.read_all(), None
+
         if isinstance(prompt, str):
             prompt = re.compile(re.escape(prompt))
         elif prompt is None:
@@ -262,7 +268,7 @@ class Prompt:
         *,
         end: str = _DEFAULT_LINE_END,
         no_echo: bool = False,
-        prompt: Union[str, re.Pattern[str], None] = None,
+        prompt: Union[str, re.Pattern[str], "EllipsisType", None] = None,
         timeout: Optional[float] = None,
     ) -> str:
         "Send some input and receive the response up to the next prompt."

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -501,3 +501,26 @@ async def test_prompt_grep_pending():
         data, m = await cli.expect("\n")
         assert data == "ghbijk"
         assert m[0] == "\n"
+
+
+async def test_prompt_grep_alternates():
+    "Test the prompt context manager with multiple pattern option."
+    cmd = sh("grep", "--line-buffered", "[bc]").set(timeout=8.0)
+
+    async with cmd.prompt(["b", "c"]) as cli:
+        await cli.send("a" * 10 + "b")
+        buf, m = await cli.expect()
+        assert cli.pending == "\n"
+        assert buf == "a" * 10
+        assert m[0] == "b"
+
+        await cli.send("d" * 10 + "c")
+        buf, m = await cli.expect()
+        assert cli.pending == "\n"
+        assert buf == "\n" + "d" * 10
+        assert m[0] == "c"
+
+        buf, m = await cli.expect(["a", "\n"])
+        assert cli.pending == ""
+        assert buf == ""
+        assert m[0] == "\n"

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -369,7 +369,7 @@ async def test_prompt_python_ps1_unicode():
         assert m and m[0] == ps1
 
         await repl.send("exit()")
-        result = await repl.read_all()
+        result, _ = await repl.expect(...)
         assert result == ""
         assert repl.at_eof
 


### PR DESCRIPTION
- Remove `default_end` setting from Prompt.
- Support `expect(...)` as alternative to read_all.
- Clean up Prompt logging.
- Add support for `expect([a, b, c])`.
- Calling expect multiple times after EOF just returns ("", None) instead of throwing an exception.