### PR TITLE
Add SHELLOUS_TRACE environment variable to control logging.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ freebsd_task:
   env:
     # for lsof
     PATH: ${PATH}:/usr/local/sbin
-    SHELLOUS_DEBUG: 1
+    SHELLOUS_TRACE: all
 
   matrix:
     - name: FreeBSD 14.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 
     env:
-      SHELLOUS_DEBUG: 1
+      SHELLOUS_TRACE: all
       BUILD_NAME: build (${{ matrix.os }},${{ matrix.python-version }})
 
     steps:
@@ -142,7 +142,7 @@ jobs:
     container:
       image: ${{ matrix.image-tag }}
     env:
-      SHELLOUS_DEBUG: 1
+      SHELLOUS_TRACE: all
       BUILD_NAME: build (${{ matrix.image-tag }})
 
     steps:
@@ -183,7 +183,7 @@ jobs:
         pypy-version: [ 'pypy-3.9', 'pypy-3.10']
 
     env:
-      SHELLOUS_DEBUG: 1
+      SHELLOUS_TRACE: all
 
     steps:
     - name: Harden Runner
@@ -211,7 +211,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20  # stop runaway job after 20 minutes
     env:
-      SHELLOUS_DEBUG: 1
+      SHELLOUS_TRACE: all
 
     steps:
     - name: Harden Runner

--- a/README.md
+++ b/README.md
@@ -566,3 +566,20 @@ sh1: CmdContext[str] = sh.set(path="/bin:/usr/bin")
 sh2: CmdContext[Result] = sh.result.set(path="/bin:/usr/bin")
 # When you use `sh2` to create commands, it produces `Command[Result]` objects with the given path.
 ```
+
+## Logging
+
+For verbose logging, shellous supports a `SHELLOUS_TRACE` environment variable. Set the
+value of `SHELLOUS_TRACE` to a comma-delimited list of options:
+
+- **detail**:  Enables detailed logging used to trace the steps of running a command.
+
+- **prompt**: Enables logging in the `Prompt` class when controlling a program
+using send/expect.
+
+- **all**: Enables all logging options.
+
+Shellous uses the built-in Python `logging` module. After enabling these options, 
+the `shellous` logger will display log messages at the `INFO` level.
+
+Without these options enabled, Shellous generates almost no log messages.

--- a/shellous/log.py
+++ b/shellous/log.py
@@ -20,15 +20,18 @@ LOGGER = logging.getLogger(__package__)
 
 _PYTHON_VERSION = platform.python_implementation() + platform.python_version()
 
-# If SHELLOUS_DEBUG option is enabled, specific methods are decorated with
-# helper methods that log function entry and exit. We also activate detailed
-# logging. If SHELLOUS_PROMPT option is enabled, we activate just the Prompt
-# class logging.
+# The the `SHELLOUS_TRACE` environment variable enables logging options. It is
+# a comma-delimited string with the following options:
+#
+#  - "detail": Enable the detailed logging method decorators.
+#  - "prompt": Enable logging of the Prompt class.
+#  - "all": Enable all logging options.
 
-SHELLOUS_DEBUG = bool(os.environ.get("SHELLOUS_DEBUG"))
+_TRACE = [s.strip().lower() for s in os.environ.get("SHELLOUS_TRACE", "").split(",")]
+_TRACE_ALL = "all" in _TRACE
 
-LOG_DETAIL = SHELLOUS_DEBUG
-LOG_PROMPT = LOG_DETAIL or bool(os.environ.get("SHELLOUS_PROMPT"))
+LOG_DETAIL = _TRACE_ALL or ("detail" in _TRACE)
+LOG_PROMPT = _TRACE_ALL or ("prompt" in _TRACE)
 
 _logger_info = LOGGER.info if LOG_DETAIL else LOGGER.debug
 

--- a/shellous/prompt.py
+++ b/shellous/prompt.py
@@ -380,12 +380,12 @@ class Prompt:
             # time to signal the end.
             stdin.write(self._runner.pty_eof * 2)
             if LOG_PROMPT:
-                LOGGER.debug("Prompt[pid=%s] send: [[EOF]]", self._runner.pid)
+                LOGGER.info("Prompt[pid=%s] send: [[EOF]]", self._runner.pid)
 
         else:
             stdin.close()
             if LOG_PROMPT:
-                LOGGER.debug("Prompt[pid=%s] close", self._runner.pid)
+                LOGGER.info("Prompt[pid=%s] close", self._runner.pid)
 
     def _finish_(self) -> None:
         "Internal method called when process exits to fetch the `Result` and cache it."
@@ -418,7 +418,7 @@ class Prompt:
                     self._at_eof = True
             except asyncio.CancelledError:
                 if LOG_PROMPT:
-                    LOGGER.debug(
+                    LOGGER.info(
                         "Prompt[pid=%s] receive cancelled: pending=%r",
                         self._runner.pid,
                         self._pending,
@@ -452,7 +452,7 @@ class Prompt:
             found = pattern.search(self._pending)
             if found:
                 if LOG_PROMPT:
-                    LOGGER.debug("Prompt[pid=%s] found: %r", self._runner.pid, found)
+                    LOGGER.info("Prompt[pid=%s] found: %r", self._runner.pid, found)
                 result = self._pending[0 : found.start(0)]
                 self._pending = self._pending[found.end(0) :]
                 return (result, found)
@@ -460,7 +460,7 @@ class Prompt:
         if self._at_eof:
             # Pattern doesn't match anything and we've reached EOF.
             if LOG_PROMPT:
-                LOGGER.debug(
+                LOGGER.info(
                     "Prompt[pid=%s] at_eof: %d chars pending",
                     self._runner.pid,
                     len(self._pending),
@@ -508,7 +508,7 @@ class Prompt:
     async def _wait_no_echo(self):
         "Wait for terminal echo mode to be disabled."
         if LOG_PROMPT:
-            LOGGER.debug("Prompt[pid=%s] wait: no_echo", self._runner.pid)
+            LOGGER.info("Prompt[pid=%s] wait: no_echo", self._runner.pid)
 
         for _ in range(4 * 30):
             if not self.echo:
@@ -522,11 +522,11 @@ class Prompt:
         pid = self._runner.pid
 
         if no_echo:
-            LOGGER.debug("Prompt[pid=%s] send: [[HIDDEN]]", pid)
+            LOGGER.info("Prompt[pid=%s] send: [[HIDDEN]]", pid)
         else:
             data_len = len(data)
             if data_len > _LOG_LIMIT:
-                LOGGER.debug(
+                LOGGER.info(
                     "Prompt[pid=%s] send: [%d B] %r...%r",
                     pid,
                     data_len,
@@ -534,7 +534,7 @@ class Prompt:
                     data[-_LOG_LIMIT_END:],
                 )
             else:
-                LOGGER.debug(
+                LOGGER.info(
                     "Prompt[pid=%s] send: [%d B] %r",
                     pid,
                     data_len,
@@ -547,7 +547,7 @@ class Prompt:
         data_len = len(data)
 
         if data_len > _LOG_LIMIT:
-            LOGGER.debug(
+            LOGGER.info(
                 "Prompt[pid=%s] receive%s: [%d B] %r...%r",
                 pid,
                 tag,
@@ -556,7 +556,7 @@ class Prompt:
                 data[-_LOG_LIMIT_END:],
             )
         else:
-            LOGGER.debug(
+            LOGGER.info(
                 "Prompt[pid=%s] receive%s: [%d B] %r",
                 pid,
                 tag,

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -4,9 +4,9 @@ import logging
 
 import pytest
 
-from shellous.log import SHELLOUS_DEBUG, log_method, log_timer
+from shellous.log import LOG_DETAIL, log_method, log_timer
 
-_LOG_LEVEL = logging.INFO if SHELLOUS_DEBUG else logging.DEBUG
+_LOG_LEVEL = logging.INFO if LOG_DETAIL else logging.DEBUG
 
 
 class _Tester:


### PR DESCRIPTION
- Remove support for SHELLOUS_DEBUG and SHELLOUS_PROMPT env. vars.
- Prompt logging takes place at INFO level under `prompt` trace setting.