### PR TITLE
feat: add limit set option

### DIFF
--- a/shellous/command.py
+++ b/shellous/command.py
@@ -181,6 +181,9 @@ class Options:  # pylint: disable=too-many-instance-attributes
     coerce_arg: _CoerceArgFnT = None
     "Function called to coerce top level arguments."
 
+    limit: Optional[int] = None
+    "Output buffer limit"
+
     def runtime_env(self) -> Optional[dict[str, str]]:
         "@private Return our `env` merged with the global environment."
         if self.inherit_env:
@@ -505,6 +508,7 @@ class Command(Generic[_RT]):
         audit_callback: Unset[_AuditFnT] = _UNSET,
         coerce_arg: Unset[_CoerceArgFnT] = _UNSET,
         error_limit: Unset[Optional[int]] = _UNSET,
+        limit: Unset[Optional[int]] = _UNSET,
     ) -> "Command[_RT]":
         """Return new command with custom options set.
 

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -294,6 +294,9 @@ class _RunOptions:
         "Set up process output. Used for both stdout and stderr."
         assert output is not None
 
+        if self.command.options.limit is not None:
+            self.kwd_args["limit"] = self.command.options.limit
+
         stdout = asyncio.subprocess.PIPE
 
         if isinstance(output, os.PathLike):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -310,6 +310,7 @@ def test_dataclasses():
         "inherit_env",
         "input",
         "input_close",
+        "limit",
         "output",
         "output_append",
         "output_close",


### PR DESCRIPTION
This option allows to alter asyncio.create_subprocess_shell limit option which allows to process output that overflows default limit.