### PR TITLE
Add support for `reader_buffer_limit` set option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,9 @@ name: ci
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
   schedule:
     # Every day at 2:02.
     - cron: '2 2 * * *'

--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ You can retrieve an option from `cmd` with `cmd.options.<option>`. For example, 
 | audit_callback | Provide function to audit stages of process execution. (Default=None) |
 | coerce_arg | Provide function to coerce `Command` arguments to strings when `str()` is not sufficient. For example, you can provide your own function that converts a dictionary argument to a sequence of strings. (Default=None) |
 | error_limit | Maximum number of initial bytes of STDERR to store in `Result` object. (Default=1024) |
+| read_buffer_limit | Maximum number of bytes to read when looking for a separator. (Default=65536) |
 
 ### env
 

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -181,6 +181,9 @@ class Options:  # pylint: disable=too-many-instance-attributes
     coerce_arg: _CoerceArgFnT = None
     "Function called to coerce top level arguments."
 
+    limit: Optional[int] = None
+    "Output buffer limit"
+
     def runtime_env(self) -> Optional[dict[str, str]]:
         "@private Return our `env` merged with the global environment."
         if self.inherit_env:
@@ -505,6 +508,7 @@ class Command(Generic[_RT]):
         audit_callback: Unset[_AuditFnT] = _UNSET,
         coerce_arg: Unset[_CoerceArgFnT] = _UNSET,
         error_limit: Unset[Optional[int]] = _UNSET,
+        limit: Unset[Optional[int]] = _UNSET,
     ) -> "Command[_RT]":
         """Return new command with custom options set.
 

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -181,8 +181,8 @@ class Options:  # pylint: disable=too-many-instance-attributes
     coerce_arg: _CoerceArgFnT = None
     "Function called to coerce top level arguments."
 
-    limit: Optional[int] = None
-    "Output buffer limit"
+    read_buffer_limit: Optional[int] = None
+    "Maximum number of bytes to read when looking for a separator."
 
     def runtime_env(self) -> Optional[dict[str, str]]:
         "@private Return our `env` merged with the global environment."
@@ -508,7 +508,7 @@ class Command(Generic[_RT]):
         audit_callback: Unset[_AuditFnT] = _UNSET,
         coerce_arg: Unset[_CoerceArgFnT] = _UNSET,
         error_limit: Unset[Optional[int]] = _UNSET,
-        limit: Unset[Optional[int]] = _UNSET,
+        read_buffer_limit: Unset[Optional[int]] = _UNSET,
     ) -> "Command[_RT]":
         """Return new command with custom options set.
 
@@ -644,6 +644,12 @@ class Command(Generic[_RT]):
         read from stderr, but will not store any additional bytes. Setting
         `error_limit` only affects the internal BUFFER; it has no effect when
         using other redirection types.
+
+        **read_buffer_limit** (int | None) default=65536<br>
+        Specify the maximum number of bytes to read from a stdout/stderr stream
+        when looking for a separator. Increase this value if you expect the
+        subprocess to emit extremely long lines. If this value is too small,
+        you may get the error: "Separator is not found".
 
         """
         kwargs = locals()

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -294,6 +294,9 @@ class _RunOptions:
         "Set up process output. Used for both stdout and stderr."
         assert output is not None
 
+        if self.command.options.limit is not None:
+            self.kwd_args["limit"] = self.command.options.limit
+
         stdout = asyncio.subprocess.PIPE
 
         if isinstance(output, os.PathLike):

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -238,6 +238,9 @@ class _RunOptions:
             preexec_fn=preexec_fn,
         )
 
+        if options.limit is not None:
+            self.kwd_args["limit"] = options.limit
+
     def _setup_pass_fds(self):
         "Set up `pass_fds` and `close_fds` if pass_fds is configured."
         options = self.command.options
@@ -293,9 +296,6 @@ class _RunOptions:
     def _setup_output(self, output: Any, append: bool, close: bool, sys_stream: TextIO):
         "Set up process output. Used for both stdout and stderr."
         assert output is not None
-
-        if self.command.options.limit is not None:
-            self.kwd_args["limit"] = self.command.options.limit
 
         stdout = asyncio.subprocess.PIPE
 

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -238,8 +238,9 @@ class _RunOptions:
             preexec_fn=preexec_fn,
         )
 
-        if options.limit is not None:
-            self.kwd_args["limit"] = options.limit
+        # Specify the `limit` argument to `asyncio.create_subprocess_exec`.
+        if options.read_buffer_limit is not None:
+            self.kwd_args["limit"] = options.read_buffer_limit
 
     def _setup_pass_fds(self):
         "Set up `pass_fds` and `close_fds` if pass_fds is configured."

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -310,6 +310,7 @@ def test_dataclasses():
         "inherit_env",
         "input",
         "input_close",
+        "limit",
         "output",
         "output_append",
         "output_close",

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -310,7 +310,6 @@ def test_dataclasses():
         "inherit_env",
         "input",
         "input_close",
-        "limit",
         "output",
         "output_append",
         "output_close",
@@ -318,6 +317,7 @@ def test_dataclasses():
         "pass_fds_close",
         "path",
         "pty",
+        "read_buffer_limit",
         "timeout",
     ]
 

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -1529,6 +1529,20 @@ async def test_bulk_line_limit(bulk_cmd):
             assert False  # never reached
 
 
+async def test_readline_limit_decreased(echo_cmd):
+    "Test line iteration with artifically lowered `read_buffer_limit`."
+    cmd1 = echo_cmd("x" * 25).set(limit=30)
+    assert [x async for x in cmd1] == ["x" * 25]
+
+
+async def test_readline_limit_too_small(echo_cmd):
+    "Test line iteration with `read_buffer_limit` too small."
+    cmd2 = echo_cmd("y" * 25).set(limit=24)
+    with pytest.raises(ValueError, match="Separator is not found"):
+        async for _ in cmd2:
+            assert False  # never reached
+
+
 def _run(cmd):
     "Run command in process pool executor."
 

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -1531,13 +1531,13 @@ async def test_bulk_line_limit(bulk_cmd):
 
 async def test_readline_limit_decreased(echo_cmd):
     "Test line iteration with artifically lowered `read_buffer_limit`."
-    cmd1 = echo_cmd("x" * 25).set(limit=30)
+    cmd1 = echo_cmd("x" * 25).set(read_buffer_limit=30)
     assert [x async for x in cmd1] == ["x" * 25]
 
 
 async def test_readline_limit_too_small(echo_cmd):
     "Test line iteration with `read_buffer_limit` too small."
-    cmd2 = echo_cmd("y" * 25).set(limit=24)
+    cmd2 = echo_cmd("y" * 25).set(read_buffer_limit=24)
     with pytest.raises(ValueError, match="Separator is not found"):
         async for _ in cmd2:
             assert False  # never reached


### PR DESCRIPTION
Add a new option `read_buffer_limit` which lets you increase the number of bytes to read when looking for a separator. If you encounter a "Separator is not found" error, you should increase this setting. Internally, this is implemented by overriding the "limit" keyword argument for `asyncio.create_subprocess_exec` (default = 64KiB).

This setting also affects the max chunk size that asyncio will read from the stdout/stderr pipes using the `read` syscall, so increasing it could affect performance.

I also fixed an issue with CI not working properly on PR's or branches with /.

This PR originated in PR #996 from @AndreyKuzmaDev