### PR TITLE
Add .pty adapter to Command and CmdContext.

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,10 +481,10 @@ process exits.
 
 ## Pseudo-Terminal Support (Unix Only)
 
-To run a command through a pseudo-terminal, set the `pty` option to True. 
+To run a command through a pseudo-terminal, use the `pty` adapter. 
 
 ```pycon
->>> await sh("echo", "in a pty").set(pty=True)
+>>> await sh.pty("echo", "in a pty")
 'in a pty\r\n'
 ```
 

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -383,6 +383,11 @@ class CmdContext(Generic[_RT]):
         return Command(coerce(args, self.options.coerce_arg), self.options)
 
     @property
+    def pty(self) -> "CmdContext[_RT]":
+        "Set `pty` to true."
+        return self.set(pty=True)
+
+    @property
     def result(self) -> "CmdContext[shellous.Result]":
         "Set `_return_result` and `exit_codes`."
         return cast(
@@ -805,6 +810,11 @@ class Command(Generic[_RT]):
     def writable(self) -> "Command[_RT]":
         "Set `writable` to True."
         return self.set(_writable=True)
+
+    @property
+    def pty(self) -> "Command[_RT]":
+        "Set `pty` to True."
+        return self.set(pty=True)
 
     @property
     def result(self) -> "Command[shellous.Result]":

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -26,9 +26,6 @@ _IS_FREEBSD = sys.platform.startswith("freebsd")
 # True if we're running on MacOS.
 _IS_MACOS = sys.platform == "darwin"
 
-# True if we're in Github Actions.
-_IS_GITHUB_ACTIONS = os.environ.get("GITHUB_ACTIONS") is not None
-
 # True if we're using uvloop.
 _IS_UVLOOP = os.environ.get("SHELLOUS_LOOP_TYPE") == "uvloop"
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -66,15 +66,18 @@ async def test_prompt_python_pty():
     )
 
     async with cmd.prompt(_PS1, timeout=3.0) as repl:
+        assert not repl.echo
+
         greeting, _ = await repl.expect()
         assert "Python" in greeting
         assert repl.pending == ""
 
+        if _IS_MACOS and repl.echo:
+            print("** echo re-enabled?")
+            repl.echo = False  # make sure echo is actually disabled (??)
+
         result = await repl.command("print('abc')")
-        if _IS_MACOS and _IS_GITHUB_ACTIONS:
-            assert result == "print('abc')\r\nabc\r\n"
-        else:
-            assert result == "abc\r\n"
+        assert result == "abc\r\n"
 
         await repl.command("exit()", allow_eof=True)
         assert repl.at_eof

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -135,7 +135,7 @@ def test_parse_readme():
         't = asyncio.create_task(sh("sleep", 60).coro())',
         "t.cancel()",
         "await t",
-        'await sh("echo", "in a pty").set(pty=True)',
+        'await sh.pty("echo", "in a pty")',
         'ls = sh("ls").set(pty=shellous.cooked(cols=40, rows=10, echo=False))',
         'await ls("README.md", "CHANGELOG.md")',
         'auditor = lambda phase, info: print(phase, info["runner"].name)',

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -2030,6 +2030,7 @@ os.write(fd, b"hello")
     assert out.read_bytes() == b"hello"
 
 
+@pytest.mark.skipif(_is_uvloop(), reason="uvloop")
 async def test_command_pty_adapter():
     "Test the .pty adapter on a Command."
     cmd = sh("echo", "abc")
@@ -2037,6 +2038,7 @@ async def test_command_pty_adapter():
     assert result == "abc\r\n"
 
 
+@pytest.mark.skipif(_is_uvloop(), reason="uvloop")
 async def test_context_pty_adapter():
     "Test the .pty adapter on a CmdContext."
     result = await sh.pty("echo", "abc")

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -2028,3 +2028,23 @@ os.write(fd, b"hello")
         await sh(sys.executable, "-c", script, fd).set(pass_fds=[fd])
 
     assert out.read_bytes() == b"hello"
+
+
+async def test_command_pty_adapter():
+    "Test the .pty adapter on a Command."
+    cmd = sh("echo", "abc")
+    result = await cmd.pty
+    assert result == "abc\r\n"
+
+
+async def test_context_pty_adapter():
+    "Test the .pty adapter on a CmdContext."
+    result = await sh.pty("echo", "abc")
+    assert result == "abc\r\n"
+
+
+async def test_pipeline_pty_adapter():
+    "Test the .pty adapter on a Pipeline (there isn't one)."
+    pipe = sh("echo", "abc") | sh("cat")
+    with pytest.raises(AttributeError, match="no attribute 'pty'"):
+        await pipe.pty


### PR DESCRIPTION
This feature allows you to invoke commands in a pty using a more concise syntax.

Instead of `sh('echo', 'abc').set(pty=True)` you can write `sh.pty('echo', 'abc')`.