### PR TITLE
Fix multiple issues with the async generators support

### DIFF
--- a/shellous/command.py
+++ b/shellous/command.py
@@ -391,7 +391,7 @@ class CmdContext(Generic[_RT]):
             CmdContext[shellous.Result],
             self.set(
                 _return_result=True,
-                exit_codes=range(-255, 256),
+                exit_codes=range(-255, 4294967295),
             ),
         )
 

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -391,7 +391,7 @@ class CmdContext(Generic[_RT]):
             CmdContext[shellous.Result],
             self.set(
                 _return_result=True,
-                exit_codes=range(-255, 4294967295),
+                exit_codes=range(-255, 2**32),
             ),
         )
 

--- a/shellous/pipeline.py
+++ b/shellous/pipeline.py
@@ -211,7 +211,7 @@ class Pipeline(Generic[_RT]):
         "Set `_return_result` and `exit_codes`."
         return cast(
             Pipeline[shellous.Result],
-            self._set(_return_result=True, exit_codes=range(-255, 256)),
+            self._set(_return_result=True, exit_codes=range(-255, 4294967295)),
         )
 
     def __await__(self) -> "Generator[Any, None, _RT]":

--- a/shellous/pipeline.py
+++ b/shellous/pipeline.py
@@ -211,7 +211,7 @@ class Pipeline(Generic[_RT]):
         "Set `_return_result` and `exit_codes`."
         return cast(
             Pipeline[shellous.Result],
-            self._set(_return_result=True, exit_codes=range(-255, 4294967295)),
+            self._set(_return_result=True, exit_codes=range(-255, 2**32)),
         )
 
     def __await__(self) -> "Generator[Any, None, _RT]":

--- a/shellous/redirect.py
+++ b/shellous/redirect.py
@@ -232,9 +232,15 @@ async def write_asyncgen(
             data = value
         else:
             raise ValueError(f"Unexpected yield from async generator: {value!r}")
+
         ends_with_newline = data.endswith(b"\n")
         stream.write(data)
-        await stream.drain()
+
+        try:
+            await stream.drain()
+        except (BrokenPipeError, ConnectionResetError):
+            # If the connection is lost, terminate the loop.
+            break
 
     await _check_eof(eof, stream, ends_with_newline)
 

--- a/shellous/redirect.py
+++ b/shellous/redirect.py
@@ -134,6 +134,11 @@ StdoutType: TypeAlias = (
 )
 
 
+class OutputInterrupted(Exception):
+    """Internal exception raised and caught to indicate that output redirection
+    was interrupted cleanly."""
+
+
 async def _drain(stream: asyncio.StreamWriter):
     "Safe drain method."
     try:
@@ -344,14 +349,14 @@ async def copy_asyncgen(
             await dest.asend(data)
 
         await dest.aclose()
-    except StopAsyncIteration:
+    except StopAsyncIteration as ex:
         # If the async generator exits early, `asend` raises a `StopAsyncIteration`
         # exception. We treat this as a request to exit the process early.
-        # Raising a CancelledError exception will cause shellous to close
+        # Raising an `OutputInterruptedError` exception will cause shellous to close
         # the process cleanly. N.B. the async generator should be written to
         # continue processing (and ignoring) bytes if it's termination should
         # not terminate the command; it should be written as an infinite loop.
-        raise asyncio.CancelledError()
+        raise OutputInterrupted() from ex
 
 
 @log_method(LOG_DETAIL)

--- a/shellous/redirect.py
+++ b/shellous/redirect.py
@@ -234,6 +234,10 @@ async def write_asyncgen(
             raise ValueError(f"Unexpected yield from async generator: {value!r}")
 
         ends_with_newline = data.endswith(b"\n")
+
+        # Break loop if stream is already closing (i.e. broken pipe).
+        if stream.is_closing():
+            break
         stream.write(data)
 
         try:

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -8,6 +8,7 @@ import os
 import sys
 from logging import Logger
 from pathlib import Path
+from signal import SIGTERM
 from types import TracebackType
 from typing import (
     Any,
@@ -41,6 +42,7 @@ from shellous.util import (
 _KILL_TIMEOUT = 3.0
 _CLOSE_TIMEOUT = 0.25
 _UNKNOWN_EXIT_CODE = 255
+_WIN32_EXIT_FAILURE = 1
 
 EVENT_SHELLOUS_EXEC = "shellous.exec"
 """Audit event raised by sys.audit() when shellous runs a subprocess.
@@ -76,11 +78,14 @@ def _is_async_gen_closed(agen: AsyncGenerator[Any, Any]) -> bool:
 
 def _map_graceful_exit_code(code: int, cancel_signal: int) -> int:
     """Map a non-zero exit code for a graceful exit to zero.
-
     Check if exit code matches the cancel_signal. On Windows, we have to be
     careful about how SIGTERM maps to `terminate()`."""
-    if code == -cancel_signal or (code == 1 and sys.platform == "win32"):
-        LOGGER.debug("Map exit_code=%r to zero.", code)
+    if code == -cancel_signal or (
+        code == _WIN32_EXIT_FAILURE
+        and cancel_signal == SIGTERM
+        and sys.platform == "win32"
+    ):
+        LOGGER.debug("result(): Map non-zero exit_code=%r to zero.", code)
         code = 0
 
     return code
@@ -467,20 +472,18 @@ class Runner:
 
     @property
     def returncode(self) -> int | None:
-        "Process's exit code, or None if process is still running."
+        "Process's exit code."
         if not self._proc:
             if self._cancelled:
                 # The process was cancelled before starting.
                 return CANCELLED_EXIT_CODE
             return None
-
         code = self._proc.returncode
         if code == _UNKNOWN_EXIT_CODE and self._last_signal is not None:
             # After sending a signal, `waitpid` may fail to locate the child
             # process. In this case, map the status to the last signal we sent.
             # For more on this, see https://github.com/python/cpython/issues/87744
             return -self._last_signal  # pylint: disable=invalid-unary-operand-type
-
         return code
 
     @property

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -24,7 +24,7 @@ import shellous.redirect as redir
 from shellous import pty_util
 from shellous.harvest import harvest, harvest_results
 from shellous.log import LOG_DETAIL, LOGGER, log_method, log_timer
-from shellous.redirect import Redirect
+from shellous.redirect import OutputInterrupted, Redirect
 from shellous.result import Result, check_result, convert_result_list
 from shellous.util import (
     BSD_DERIVED,
@@ -425,6 +425,7 @@ class Runner:
     _timer: asyncio.TimerHandle | None = None
     _timed_out: bool = False
     _last_signal: int | None = None
+    _ignore_cancel_signal: bool = False
 
     def __init__(self, command: "shellous.Command[Any]"):
         self._options = _RunOptions(command)
@@ -454,18 +455,31 @@ class Runner:
 
     @property
     def returncode(self) -> int | None:
-        "Process's exit code."
+        "Process's exit code, or None if process is still running."
         if not self._proc:
             if self._cancelled:
                 # The process was cancelled before starting.
                 return CANCELLED_EXIT_CODE
             return None
+
         code = self._proc.returncode
+        if code is None:
+            # Process is still running.
+            return None
+
         if code == _UNKNOWN_EXIT_CODE and self._last_signal is not None:
             # After sending a signal, `waitpid` may fail to locate the child
             # process. In this case, map the status to the last signal we sent.
             # For more on this, see https://github.com/python/cpython/issues/87744
             return -self._last_signal  # pylint: disable=invalid-unary-operand-type
+
+        if self._ignore_cancel_signal and not self._cancelled:
+            cancel_signal = self.command.options.cancel_signal
+            if cancel_signal is not None and code == -cancel_signal:
+                # Treat an exit status of the cancel signal as "graceful".
+                # (See the `OutputInterrupted` exception.)
+                code = 0
+
         return code
 
     @property
@@ -559,6 +573,14 @@ class Runner:
             LOGGER.debug("Runner.wait cancelled %r", self)
             self._set_cancelled()
             self._tasks.clear()  # all tasks were cancelled
+            await self._kill()
+
+        except OutputInterrupted:
+            LOGGER.debug("Runner.wait output interrupted %r", self)
+            self._tasks.clear()  # all tasks were cancelled
+            # Abort process but map the negative exit_code from the cancel
+            # signal to 0.
+            self._ignore_cancel_signal = True
             await self._kill()
 
         except Exception as ex:

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -74,6 +74,19 @@ def _is_async_gen_closed(agen: AsyncGenerator[Any, Any]) -> bool:
     return inspect.getasyncgenstate(agen) == inspect.AGEN_CLOSED
 
 
+def _map_graceful_exit_code(code: int, cancel_signal: int | None) -> int:
+    "Map a non-zero exit code for a graceful exit to zero."
+    if cancel_signal is None:
+        return code
+
+    # Check if exit code matches the cancel_signal. On Windows, we have to be
+    # careful about how SIGTERM maps to `terminate()`.
+    if code == -cancel_signal or (code == 1 and sys.platform == "win32"):
+        code = 0
+
+    return code
+
+
 class _RunOptions:
     """_RunOptions is context manager to assist in running a command.
 
@@ -474,11 +487,9 @@ class Runner:
             return -self._last_signal  # pylint: disable=invalid-unary-operand-type
 
         if self._ignore_cancel_signal and not self._cancelled:
+            # To see how this is used, look for `OutputInterrupted` exception.
             cancel_signal = self.command.options.cancel_signal
-            if cancel_signal is not None and code == -cancel_signal:
-                # Treat an exit status of the cancel signal as "graceful".
-                # (See the `OutputInterrupted` exception.)
-                code = 0
+            code = _map_graceful_exit_code(code, cancel_signal)
 
         return code
 

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -74,14 +74,13 @@ def _is_async_gen_closed(agen: AsyncGenerator[Any, Any]) -> bool:
     return inspect.getasyncgenstate(agen) == inspect.AGEN_CLOSED
 
 
-def _map_graceful_exit_code(code: int, cancel_signal: int | None) -> int:
-    "Map a non-zero exit code for a graceful exit to zero."
-    if cancel_signal is None:
-        return code
+def _map_graceful_exit_code(code: int, cancel_signal: int) -> int:
+    """Map a non-zero exit code for a graceful exit to zero.
 
-    # Check if exit code matches the cancel_signal. On Windows, we have to be
-    # careful about how SIGTERM maps to `terminate()`.
+    Check if exit code matches the cancel_signal. On Windows, we have to be
+    careful about how SIGTERM maps to `terminate()`."""
     if code == -cancel_signal or (code == 1 and sys.platform == "win32"):
+        LOGGER.debug("Map exit_code=%r to zero.", code)
         code = 0
 
     return code
@@ -476,20 +475,11 @@ class Runner:
             return None
 
         code = self._proc.returncode
-        if code is None:
-            # Process is still running.
-            return None
-
         if code == _UNKNOWN_EXIT_CODE and self._last_signal is not None:
             # After sending a signal, `waitpid` may fail to locate the child
             # process. In this case, map the status to the last signal we sent.
             # For more on this, see https://github.com/python/cpython/issues/87744
             return -self._last_signal  # pylint: disable=invalid-unary-operand-type
-
-        if self._ignore_cancel_signal and not self._cancelled:
-            # To see how this is used, look for `OutputInterrupted` exception.
-            cancel_signal = self.command.options.cancel_signal
-            code = _map_graceful_exit_code(code, cancel_signal)
 
         return code
 
@@ -525,6 +515,13 @@ class Runner:
         code = self.returncode
         if code is None:
             raise TypeError("Runner.result(): Process has not exited")
+
+        if self._ignore_cancel_signal and not self._cancelled:
+            # Check if we need to replace a non-zero exit code for an early
+            # terminated process with zero. (See `OutputInterrupted`)
+            cancel_signal = self.command.options.cancel_signal
+            if cancel_signal is not None:
+                code = _map_graceful_exit_code(code, cancel_signal)
 
         result = Result(
             exit_code=code,

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -340,7 +340,7 @@ def test_context_result():
     "Test that `sh` supports the .result modifier."
     ctxt = sh.result
     assert ctxt.options._return_result
-    assert ctxt.options.exit_codes == range(-255, 4294967295)
+    assert ctxt.options.exit_codes == range(-255, 2**32)
 
 
 def test_command_invalid_encoding():

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -340,7 +340,7 @@ def test_context_result():
     "Test that `sh` supports the .result modifier."
     ctxt = sh.result
     assert ctxt.options._return_result
-    assert ctxt.options.exit_codes == range(-255, 256)
+    assert ctxt.options.exit_codes == range(-255, 4294967295)
 
 
 def test_command_invalid_encoding():

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -738,17 +738,35 @@ async def test_pipe_redirect_stdout_async_generator_early_exit():
     result = await cmd.result()
     assert buf == b"abc\n"
     assert result.output == ""
+    # NOTE: The default behavior is `pipefail`.
+    assert _is_broken_pipe(result.exit_code)
 
-    # FIXME: The default behavior is `pipefail`. The pipe will return non-zero
-    # exit code due to broken pipe in 2nd-to-last cat. In the future, implement
-    # a way to disable `pipefail`?
+
+async def test_pipe_head_early_exit():
+    "Test pipe writing to unix `head` tool that exits early."
+
+    async def _input():
+        yield "abc\n"  # chunk 1
+        while True:
+            await asyncio.sleep(0.1)
+            yield "def\n"  # infinite chunks...
+
+    cmd = _input() | sh("cat") | sh("head", "-n", 1)
+    result = await cmd.result()
+    assert result.output == "abc\n"
+    # NOTE: The default behavior is `pipefail`
+    assert _is_broken_pipe(result.exit_code)
+
+
+def _is_broken_pipe(exit_code: int) -> bool:
+    "Return true if `exit_code` matches the broken pipe error."
     if sys.platform == "win32":
-        _SIGPIPE_WIN32 = 3328  # from `cat` on windows-2025.
-        assert result.exit_code == _SIGPIPE_WIN32
-    else:
-        from signal import SIGPIPE
+        _SIGPIPE_WIN32 = 0xD00  # 0xD00 = SIGPIPE(13) << 8
+        return exit_code == _SIGPIPE_WIN32
 
-        assert result.exit_code == -SIGPIPE
+    from signal import SIGPIPE
+
+    return exit_code == -SIGPIPE
 
 
 async def test_broken_pipe():
@@ -1775,8 +1793,10 @@ async def test_process_pool_executor(echo_cmd, report_children):
 
 
 def test_cross_platform_executables_exist():
-    "Test that executables in this file exist on all platforms."
-    cmds = ["echo", "cat"]
+    """Test that executables used in this test module exist on all platforms.
+
+    On Windows test hosts, these are in included with a git.exe install."""
+    cmds = ["echo", "cat", "head"]
     for cmd in cmds:
         result = sh.find_command(cmd)
         assert result is not None, cmd

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -674,8 +674,9 @@ async def test_redirect_stdout_async_generator_early_exit():
 
     async def _input():
         yield "abc\n"  # chunk 1
-        await asyncio.sleep(0.5)
-        yield "def\n"  # chunk 2
+        while True:
+            await asyncio.sleep(0.5)
+            yield "def\n"  # infinite chunks...
 
     async def _output(buf: bytearray):
         data = yield  # chunk 1 only

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -742,7 +742,9 @@ async def test_pipe_redirect_stdout_async_generator_early_exit():
     # fail due to broken pipe in 2nd-to-last cat. In the future, implement
     # a way to disable `pipefail`?
     assert result.output == ""
-    assert result.exit_code == -13  # FIXME: need win32 value
+    _SIGPIPE = -13
+    _SIGPIPE_WIN32 = 3328  # from `cat` on windows-2025.
+    assert result.exit_code in (_SIGPIPE, _SIGPIPE_WIN32)
 
 
 async def test_broken_pipe():

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -737,14 +737,18 @@ async def test_pipe_redirect_stdout_async_generator_early_exit():
     cmd = _input() | sh("cat") | sh("cat") | sh("cat") | _output(buf)
     result = await cmd.result()
     assert buf == b"abc\n"
-
-    # FIXME: The default behavior is `pipefail`. The entire pipeline will
-    # fail due to broken pipe in 2nd-to-last cat. In the future, implement
-    # a way to disable `pipefail`?
     assert result.output == ""
-    _SIGPIPE = -13
-    _SIGPIPE_WIN32 = 3328  # from `cat` on windows-2025.
-    assert result.exit_code in (_SIGPIPE, _SIGPIPE_WIN32)
+
+    # FIXME: The default behavior is `pipefail`. The pipe will return non-zero
+    # exit code due to broken pipe in 2nd-to-last cat. In the future, implement
+    # a way to disable `pipefail`?
+    if sys.platform == "win32":
+        _SIGPIPE_WIN32 = 3328  # from `cat` on windows-2025.
+        assert result.exit_code == _SIGPIPE_WIN32
+    else:
+        from signal import SIGPIPE
+
+        assert result.exit_code == -SIGPIPE
 
 
 async def test_broken_pipe():
@@ -1768,3 +1772,12 @@ async def test_process_pool_executor(echo_cmd, report_children):
     from multiprocessing import resource_tracker
 
     resource_tracker._resource_tracker._stop()  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_cross_platform_executables_exist():
+    "Test that executables in this file exist on all platforms."
+    cmds = ["echo", "cat"]
+    for cmd in cmds:
+        result = sh.find_command(cmd)
+        assert result is not None, cmd
+        print(repr(result))

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -720,6 +720,31 @@ async def test_redirect_stdout_async_generator_closed(echo_cmd):
         await cmd
 
 
+async def test_pipe_redirect_stdout_async_generator_early_exit():
+    "Test pipe writing stdout to an async generator that exits early."
+
+    async def _input():
+        yield "abc\n"  # chunk 1
+        while True:
+            await asyncio.sleep(1.0)
+            yield "def\n"  # infinite chunks...
+
+    async def _output(buf: bytearray):
+        data = yield  # chunk 1 only
+        buf.extend(data)
+
+    buf = bytearray()
+    cmd = _input() | sh("cat") | sh("cat") | sh("cat") | _output(buf)
+    result = await cmd.result()
+    assert buf == b"abc\n"
+
+    # FIXME: The default behavior is `pipefail`. The entire pipeline will
+    # fail due to broken pipe in 2nd-to-last cat. In the future, implement
+    # a way to disable `pipefail`?
+    assert result.output == ""
+    assert result.exit_code == -13  # FIXME: need win32 value
+
+
 async def test_broken_pipe():
     """Test broken pipe error for large data passed to stdin.
 

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -1670,26 +1670,25 @@ async def test_pty_redirect_stdout_asyncgen_early_exit():
 
     async def _input():
         yield "abc\n"  # chunk 1
-        await asyncio.sleep(0.5)
-        yield "def\n"  # chunk 2
+        while True:
+            await asyncio.sleep(1.0)
+            yield "def\n"  # chunk 2
 
     async def _output(buf: bytearray):
-        data = yield  # chunk 1 only
-        buf.extend(data)
+        while True:
+            data = yield
+            buf.extend(data)
+            pos = buf.find(b"\r\n")
+            if pos >= 0:
+                buf.resize(pos + 2)
+                return  # exit after first line is received
 
     buf = bytearray()
     result = await (_input() | sh("cat") | _output(buf)).set(pty=True)
     assert result == ""
 
     output = buf.replace(b"^D\x08\x08", b"")
-    if _is_codecov():
-        # FIXME: Under code coverage, some of the output is sometimes truncated?
-        # Is there a timing issue when cancelling the process that prevents the
-        # rest of the output from being read from the terminal driver? Check
-        # if issue can be replicated outside of code coverage. 2026-07-06
-        assert output == b"abc\r\nabc\r\n" or b"abc\r\n"
-    else:
-        assert output == b"abc\r\nabc\r\n"
+    assert output == b"abc\r\n"
 
 
 @pytest.mark.skipif(_is_uvloop(), reason="uvloop")

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -1680,7 +1680,7 @@ async def test_pty_redirect_stdout_asyncgen_early_exit():
             buf.extend(data)
             pos = buf.find(b"\r\n")
             if pos >= 0:
-                buf.resize(pos + 2)
+                buf[pos + 2 :] = b""
                 return  # exit after first line is received
 
     buf = bytearray()


### PR DESCRIPTION
- Fix bug on Windows in `sh.result` modifier: exit status can be > 255 on Windows.
- Async generator output now relies on OutputInterrupted internal exception to cleanly shut down process rather than CancelledError. This causes the exit status of the "interrupted" process to be mapped to zero.
- Add tests for pipes that use "one line" async generators as output. 
- Add a test for a pipe that uses the "head" tool to cut the output short. Fix issue with BrokenPipeError and ConnectionResetError exceptions in async generator input.