### PR TITLE
Preliminary implementation of `cwd` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ You can retrieve an option from `cmd` with `cmd.options.<option>`. For example, 
 | Option | Description |
 | --- | --- |
 | path | Search path to use instead of the `PATH` environment variable. (Default=None) |
+| cwd | Override current working directory for the process. By default, the process inherits the current working directory of its parent process. (Default=None)
 | env | Additional environment variables to pass to the command. (Default={}) |
 | inherit_env | True if command should inherit the environment variables from the current process. (Default=True) |
 | encoding | Text encoding of input/output streams. You can specify an error handling scheme by including it after a space, e.g. "ascii backslashreplace". (Default="utf-8 strict") |

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -98,6 +98,9 @@ class Options:  # pylint: disable=too-many-instance-attributes
     path: str | None = None
     "Optional search path to use instead of PATH environment variable."
 
+    cwd: Path | str | None = None
+    "Current working directory for running process."
+
     env: EnvironmentDict | None = field(default=None, repr=False)
     "Additional environment variables for command."
 
@@ -344,6 +347,7 @@ class CmdContext(Generic[_RT]):
         self,
         *,
         path: Unset[str | None] = _UNSET,
+        cwd: Unset[Path | None] = _UNSET,
         env: Unset[dict[str, Any]] = _UNSET,
         inherit_env: Unset[bool] = _UNSET,
         encoding: Unset[str] = _UNSET,
@@ -497,6 +501,7 @@ class Command(Generic[_RT]):
         self,
         *,
         path: Unset[str | None] = _UNSET,
+        cwd: Unset[Path | None] = _UNSET,
         env: Unset[dict[str, Any]] = _UNSET,
         inherit_env: Unset[bool] = _UNSET,
         encoding: Unset[str] = _UNSET,
@@ -524,6 +529,13 @@ class Command(Generic[_RT]):
         **path** (str | None) default=None<br>
         Search path for locating command executable. By default, `path` is None
         which causes shellous to rely on the `PATH` environment variable.
+
+        **cwd** (Path | None) default=None<br>
+        Set current working directory for running subprocess. The default of
+        None causes the process to inherit the current working directory from
+        the parent Python process. The `cwd` setting does not affect how
+        relative paths to the executable or stdin/stdout/stderr are resolved by
+        the parent Python process.
 
         **env** (dict[str, str]) default={}<br>
         Set the environment variables for the subprocess. If `inherit_env` is

--- a/shellous/command.py
+++ b/shellous/command.py
@@ -347,7 +347,7 @@ class CmdContext(Generic[_RT]):
         self,
         *,
         path: Unset[str | None] = _UNSET,
-        cwd: Unset[Path | None] = _UNSET,
+        cwd: Unset[Path | str | None] = _UNSET,
         env: Unset[dict[str, Any]] = _UNSET,
         inherit_env: Unset[bool] = _UNSET,
         encoding: Unset[str] = _UNSET,
@@ -501,7 +501,7 @@ class Command(Generic[_RT]):
         self,
         *,
         path: Unset[str | None] = _UNSET,
-        cwd: Unset[Path | None] = _UNSET,
+        cwd: Unset[Path | str | None] = _UNSET,
         env: Unset[dict[str, Any]] = _UNSET,
         inherit_env: Unset[bool] = _UNSET,
         encoding: Unset[str] = _UNSET,
@@ -530,7 +530,7 @@ class Command(Generic[_RT]):
         Search path for locating command executable. By default, `path` is None
         which causes shellous to rely on the `PATH` environment variable.
 
-        **cwd** (Path | None) default=None<br>
+        **cwd** (Path | str | None) default=None<br>
         Set current working directory for running subprocess. The default of
         None causes the process to inherit the current working directory from
         the parent Python process. The `cwd` setting does not affect how

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -142,15 +142,7 @@ class _RunOptions:
 
             self._setup_redirects()
             self._setup_pass_fds()
-
-            # If executable does not include an absolute/relative directory,
-            # resolve it using PATH.
-            executable = self.pos_args[0]
-            if not os.path.dirname(executable):
-                found_executable = _cmd.options.which(executable)
-                if found_executable is None:
-                    raise FileNotFoundError(executable)
-                self.pos_args[0] = found_executable
+            self._setup_executable()
 
         except Exception as ex:
             if LOG_DETAIL:
@@ -290,6 +282,24 @@ class _RunOptions:
         elif "close_fds" not in self.kwd_args:
             # Only set close_fds if it is not already set.
             self.kwd_args["close_fds"] = options.close_fds
+
+    def _setup_executable(self):
+        """Set executable's correct path and current working directory.
+
+        If executable does not include an absolute/relative directory,
+        resolve it using PATH.
+        """
+        options = self.command.options
+        executable = self.pos_args[0]
+        if not os.path.dirname(executable):
+            found_executable = options.which(executable)
+            if found_executable is None:
+                raise FileNotFoundError(executable)
+            self.pos_args[0] = found_executable
+
+        # Set current working directory, if specified.
+        if options.cwd is not None:
+            self.kwd_args["cwd"] = os.path.realpath(options.cwd, strict=True)
 
     def _setup_input(self, input_: Any, close: bool, encoding: str):
         "Set up process input."

--- a/shellous/runner.py
+++ b/shellous/runner.py
@@ -291,15 +291,24 @@ class _RunOptions:
         """
         options = self.command.options
         executable = self.pos_args[0]
+        cwd = options.cwd
+
         if not os.path.dirname(executable):
+            # Resolve path to executable using PATH.
             found_executable = options.which(executable)
             if found_executable is None:
                 raise FileNotFoundError(executable)
             self.pos_args[0] = found_executable
+        elif cwd and not os.path.isabs(executable):
+            # If `cwd`is set, make sure that executable path is absolute.
+            # Without this adjustment, POSIX systems will resolve a relative
+            # executable path using `cwd`, but Windows will use the process
+            # current working directory.
+            self.pos_args[0] = os.path.abspath(executable)
 
         # Set current working directory, if specified.
-        if options.cwd is not None:
-            self.kwd_args["cwd"] = os.path.realpath(options.cwd, strict=True)
+        if cwd is not None:
+            self.kwd_args["cwd"] = os.path.abspath(cwd)
 
     def _setup_input(self, input_: Any, close: bool, encoding: str):
         "Set up process input."

--- a/tests/python_script.py
+++ b/tests/python_script.py
@@ -68,6 +68,9 @@ elif SHELLOUS_CMD == "error":
 
     sys.stderr.buffer.flush()
 
+elif SHELLOUS_CMD == "cwd":
+    _write(os.getcwd().encode())
+
 else:
     raise NotImplementedError
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -92,7 +92,7 @@ def test_repr():
     assert "SECRET" not in result
 
 
-def test_non_existant():
+def test_non_existent():
     "Commands can be created with a bogus program name."
     cmd = sh("/bogus/zzz")
     assert cmd.args == ("/bogus/zzz",)

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -306,6 +306,7 @@ def test_dataclasses():
         "cancel_timeout",
         "close_fds",
         "coerce_arg",
+        "cwd",
         "encoding",
         "env",
         "error",

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -1883,6 +1883,7 @@ async def test_cwd_executable_relative_path():
     assert cmd is not None
 
     with _working_dir(cmd.parent):
+        # Python working directory is set to where `echo` is located.
         out = await sh("./echo", "abc")
         assert out.rstrip() == "abc"
 
@@ -1892,3 +1893,32 @@ async def test_cwd_executable_relative_path():
             # not use the value of `cwd`.
             out = await sh("./echo", "abc").set(cwd=tmpdir)
             assert out.rstrip() == "abc"
+
+
+async def test_cwd_does_not_affect_stdin_and_stdout():
+    "Test that the cwd option does not affect the stdin/stdout."
+    with TemporaryDirectory() as tmpdir:
+        tmp_dir = Path(tmpdir)
+        sub_dir = tmp_dir / "subdir"
+        sub_dir.mkdir()
+
+        out_file = tmp_dir / "out_file.txt"
+        in_file = tmp_dir / "in_file.txt"
+        in_file.write_bytes(b"12345")
+
+        cmd = Path("in_file.txt") | sh("cat") | Path("out_file.txt")
+
+        # Does not work because cwd doesn't affect stdin/stdout and the files
+        # aren't in sub_dir.
+        with _working_dir(sub_dir):
+            with pytest.raises(FileNotFoundError):
+                await cmd.set(cwd=tmp_dir)
+
+        # Make sure out_file.txt was never created.
+        assert not (sub_dir / "out_file.txt").exists()
+
+        # Works when we set the Python working directory itself to tmp_dir.
+        with _working_dir(tmp_dir):
+            out = await cmd.set(cwd=tmp_dir)
+            assert out == ""
+            assert out_file.read_bytes() == b"12345"

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -3,12 +3,14 @@
 # pylint: disable=redefined-outer-name,invalid-name
 
 import asyncio
+import contextlib
 import hashlib
 import io
 import logging
 import os
 import sys
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import asyncstdlib as asl
 import pytest
@@ -62,7 +64,7 @@ def python_script():
     The script behaves like common versions of `echo`, `cat`, `sleep` or `env`
     depending on environment variables.
     """
-    source_file = Path("tests/python_script.py")
+    source_file = Path("tests/python_script.py").resolve()
     return sh(sys.executable, "-u", source_file).stderr(sh.INHERIT)
 
 
@@ -104,6 +106,11 @@ def count_cmd(python_script):
 @pytest.fixture
 def error_cmd(python_script):
     return python_script.env(SHELLOUS_CMD="error").set(alt_name="error")
+
+
+@pytest.fixture
+def cwd_cmd(python_script):
+    return python_script.env(SHELLOUS_CMD="cwd").set(alt_name="cwd")
 
 
 async def test_echo(echo_cmd):
@@ -159,6 +166,11 @@ async def test_bulk_prompt(bulk_cmd, _limit_logging):
 async def test_count(count_cmd):
     result = await count_cmd(5)
     assert result == "1\n2\n3\n4\n5\n"
+
+
+async def test_cwd(cwd_cmd):
+    result = await cwd_cmd
+    assert result == os.getcwd()
 
 
 async def test_error(error_cmd):
@@ -1801,3 +1813,47 @@ def test_cross_platform_executables_exist():
         result = sh.find_command(cmd)
         assert result is not None, cmd
         print(repr(result))
+
+
+@contextlib.contextmanager
+def _working_dir(path: Path):
+    "Context manager to set working directory."
+    saved_cwd = Path.cwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(saved_cwd)
+
+
+async def test_cwd_option(cwd_cmd):
+    "Test the `cwd` option using a temporary directory."
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir).resolve() / "test_cwd_xyz"
+        tmp_path.mkdir()
+        tmp_str = str(tmp_path)
+
+        # Test using `Path` object.
+        out = await cwd_cmd.set(cwd=tmp_path)
+        assert out == tmp_str
+
+        # Test using `str` object.
+        out = await cwd_cmd.set(cwd=tmp_str)
+        assert out == tmp_str
+
+        # Test using `bytes` object (Note: Isn't typed this way.)
+        out = await cwd_cmd.set(cwd=tmp_str.encode())
+        assert out == tmp_str
+
+        # Test using a non-existant directory.
+        with pytest.raises(FileNotFoundError, match="does_not_exist"):
+            await cwd_cmd.set(cwd=tmp_path / "does_not_exist")
+
+        # Test using invalid path type.
+        with pytest.raises(TypeError, match="Path"):
+            await cwd_cmd.set(cwd=7)
+
+        # Test using relative path for `cwd`.
+        with _working_dir(tmp_path.parent):
+            out = await cwd_cmd.set(cwd="test_cwd_xyz")
+            assert out == tmp_str

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -279,9 +279,9 @@ async def test_pipeline_error_only():
     assert out[0].rstrip() == "abc"
 
 
-async def test_nonexistant_cmd():
+async def test_nonexistent_cmd():
     with pytest.raises(FileNotFoundError):
-        await sh("non_existant_command").set(_return_result=True)
+        await sh("non_existent_command").set(_return_result=True)
 
 
 async def test_nonexecutable_cmd():
@@ -1142,7 +1142,7 @@ async def test_pathlike_args_and_which():
     found = cmd.options.which(Path("echo"))
     assert found and isinstance(found, str)
 
-    assert cmd.options.which(Path("12345_non_existant")) is None
+    assert cmd.options.which(Path("12345_non_existent")) is None
 
 
 async def test_command_context_manager_default():
@@ -1845,10 +1845,6 @@ async def test_cwd_option(cwd_cmd):
         out = await cwd_cmd.set(cwd=tmp_str.encode())
         assert out == tmp_str
 
-        # Test using a non-existant directory.
-        with pytest.raises(FileNotFoundError, match="does_not_exist"):
-            await cwd_cmd.set(cwd=tmp_path / "does_not_exist")
-
         # Test using invalid path type.
         with pytest.raises(TypeError, match="Path"):
             await cwd_cmd.set(cwd=7)
@@ -1857,6 +1853,17 @@ async def test_cwd_option(cwd_cmd):
         with _working_dir(tmp_path.parent):
             out = await cwd_cmd.set(cwd="test_cwd_xyz")
             assert out == tmp_str
+
+
+async def test_cwd_non_existent(cwd_cmd):
+    "Test the `cwd` option with a non-existent directory."
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+
+        # On Windows, the error is "NotADirectoryError".
+        exc = NotADirectoryError if sys.platform == "win32" else FileNotFoundError
+        with pytest.raises(exc):
+            await cwd_cmd.set(cwd=tmp_path / "does_not_exist")
 
 
 async def test_cwd_cat_cmd_arg(cat_cmd):

--- a/tests/test_shellous.py
+++ b/tests/test_shellous.py
@@ -64,7 +64,7 @@ def python_script():
     The script behaves like common versions of `echo`, `cat`, `sleep` or `env`
     depending on environment variables.
     """
-    source_file = Path("tests/python_script.py").resolve()
+    source_file = Path("tests/python_script.py").absolute()
     return sh(sys.executable, "-u", source_file).stderr(sh.INHERIT)
 
 
@@ -1857,3 +1857,31 @@ async def test_cwd_option(cwd_cmd):
         with _working_dir(tmp_path.parent):
             out = await cwd_cmd.set(cwd="test_cwd_xyz")
             assert out == tmp_str
+
+
+async def test_cwd_cat_cmd_arg(cat_cmd):
+    "Test the `cwd` option to cat a temporary file in specified directory."
+    with TemporaryDirectory() as tmpdir:
+        tmp_dir = Path(tmpdir)
+        tmp_file = tmp_dir / "test_file1"
+        tmp_file.write_bytes(b"abcdef")
+
+        out = await cat_cmd("./test_file1").set(cwd=tmp_dir)
+        assert out == "abcdef"
+
+
+async def test_cwd_executable_relative_path():
+    "Test the cwd option when the executable uses a relative path."
+    cmd = sh.find_command("echo")
+    assert cmd is not None
+
+    with _working_dir(cmd.parent):
+        out = await sh("./echo", "abc")
+        assert out.rstrip() == "abc"
+
+        with TemporaryDirectory() as tmpdir:
+            # When using `cwd`, the relative path should still be resolved using
+            # the parent Python process current working directory. It should
+            # not use the value of `cwd`.
+            out = await sh("./echo", "abc").set(cwd=tmpdir)
+            assert out.rstrip() == "abc"

--- a/tests/unix/test_unix.py
+++ b/tests/unix/test_unix.py
@@ -189,7 +189,7 @@ async def test_custom_echo_shorthand():
 
 
 async def test_missing_executable():
-    "Test invoking a non-existant command raises a FileNotFoundError."
+    "Test invoking a non-existent command raises a FileNotFoundError."
     with pytest.raises(FileNotFoundError):
         await sh("/bin/does_not_exist")
 
@@ -559,14 +559,14 @@ async def test_pipeline_single_cmd():
 
 
 async def test_pipeline_invalid_cmd1():
-    pipe = sh(" non_existant ", "xyz") | sh("tr", "[:lower:]", "[:upper:]")
+    pipe = sh(" non_existent ", "xyz") | sh("tr", "[:lower:]", "[:upper:]")
     # uvloop's error message does not include filename.
     with pytest.raises(FileNotFoundError):
         await pipe
 
 
 async def test_pipeline_invalid_cmd2():
-    pipe = sh("echo", "abc") | sh(" non_existant ", "xyz")
+    pipe = sh("echo", "abc") | sh(" non_existent ", "xyz")
     # uvloop's error message does not include filename.
     with pytest.raises(FileNotFoundError):
         await pipe


### PR DESCRIPTION
Other change: spell "existent" correctly.